### PR TITLE
Operator tcp input scanner buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Added TLS support to `tcp_input` operator
+- Added optional `max_buffer_size` parameter to `tcp_input` operator
 
 ## [0.15.0] - 2020-02-25
 

--- a/docs/operators/tcp_input.md
+++ b/docs/operators/tcp_input.md
@@ -8,6 +8,7 @@ The `tcp_input` operator listens for logs on one or more TCP connections. The op
 | ---               | ---              | ---                                                                               |
 | `id`              | `tcp_input`      | A unique identifier for the operator                                              |
 | `output`          | Next in pipeline | The connected operator(s) that will receive all outbound entries                  |
+| `max_buffer_size` | `1024kib`        | Maximum size of buffer that may be allocated while reading TCP input              |
 | `listen_address`  | required         | A listen address of the form `<ip>:<port>`                                        |
 | `tls`             |                  | An optional `TLS` configuration (see the TLS configuration section)               |
 | `write_to`        | $                | The record [field](/docs/types/field.md) written to when creating a new log entry |


### PR DESCRIPTION
Added optional max_buffer_size parameter to tcp_input operator. This is useful for situations where TCP input is handling payloads larger than the default scanner's buffer. 

For more context, see:
Original Stanza issue https://github.com/observIQ/stanza/issues/255
Original Stanza PR https://github.com/observIQ/stanza/pull/256