### PR TITLE
Require a namespace when using offsets database

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -24,8 +24,9 @@ import (
 
 // LogAgent is an entity that handles log monitoring.
 type LogAgent struct {
-	database database.Database
-	pipeline pipeline.Pipeline
+	instanceName string
+	database     database.Database
+	pipeline     pipeline.Pipeline
 
 	startOnce sync.Once
 	stopOnce  sync.Once

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -24,9 +24,8 @@ import (
 
 // LogAgent is an entity that handles log monitoring.
 type LogAgent struct {
-	instanceName string
-	database     database.Database
-	pipeline     pipeline.Pipeline
+	database database.Database
+	pipeline pipeline.Pipeline
 
 	startOnce sync.Once
 	stopOnce  sync.Once

--- a/agent/builder.go
+++ b/agent/builder.go
@@ -15,6 +15,7 @@
 package agent
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-log-collection/database"
@@ -31,6 +32,7 @@ type LogAgentBuilder struct {
 	config        *Config
 	logger        *zap.SugaredLogger
 	pluginDir     string
+	namespace     string
 	databaseFile  string
 	defaultOutput operator.Operator
 }
@@ -61,8 +63,9 @@ func (b *LogAgentBuilder) WithConfig(cfg *Config) *LogAgentBuilder {
 }
 
 // WithDatabaseFile adds the specified database file when building a log agent
-func (b *LogAgentBuilder) WithDatabaseFile(databaseFile string) *LogAgentBuilder {
+func (b *LogAgentBuilder) WithDatabaseFile(databaseFile, namespace string) *LogAgentBuilder {
 	b.databaseFile = databaseFile
+	b.namespace = namespace
 	return b
 }
 
@@ -74,6 +77,11 @@ func (b *LogAgentBuilder) WithDefaultOutput(defaultOutput operator.Operator) *Lo
 
 // Build will build a new log agent using the values defined on the builder
 func (b *LogAgentBuilder) Build() (*LogAgent, error) {
+
+	if b.databaseFile != "" && b.namespace == "" {
+		return nil, fmt.Errorf("use of database requires namespace")
+	}
+
 	db, err := database.OpenDatabase(b.databaseFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "open database")
@@ -105,6 +113,10 @@ func (b *LogAgentBuilder) Build() (*LogAgent, error) {
 	).Sugar()
 
 	buildContext := operator.NewBuildContext(db, sampledLogger)
+	if b.namespace != "" {
+		buildContext = buildContext.WithSubNamespace(b.namespace)
+	}
+
 	pipeline, err := b.config.Pipeline.BuildPipeline(buildContext, b.defaultOutput)
 	if err != nil {
 		return nil, err

--- a/agent/builder.go
+++ b/agent/builder.go
@@ -77,7 +77,6 @@ func (b *LogAgentBuilder) WithDefaultOutput(defaultOutput operator.Operator) *Lo
 
 // Build will build a new log agent using the values defined on the builder
 func (b *LogAgentBuilder) Build() (*LogAgent, error) {
-
 	if b.databaseFile != "" && b.namespace == "" {
 		return nil, fmt.Errorf("use of database requires namespace")
 	}


### PR DESCRIPTION
This is necessary in order to allow multiple pipelines to run in the same process without being at risk of overwriting offsets.