### PR TITLE
Update Router doc to reflect default field change

### DIFF
--- a/docs/operators/router.md
+++ b/docs/operators/router.md
@@ -54,6 +54,5 @@ An entry that does not match any of the routes is dropped and not processed furt
   routes:
     - output: my_json_parser
       expr: '$.format == "json"'
-    - output: catchall
-      expr: 'true'
+  default: catchall
 ```


### PR DESCRIPTION
Update Router doc to reflect default field change. This affects the example showing how to use default outputs.