### PR TITLE
Support whole number float64 type for severity parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Added float64 to Severity parser's supported types
 
 ## [0.16.0] - 2020-03-08
 

--- a/operator/helper/severity.go
+++ b/operator/helper/severity.go
@@ -72,6 +72,15 @@ func (m severityMap) find(value interface{}) (entry.Severity, string, error) {
 			return severity, strV, nil
 		}
 		return entry.Default, strV, nil
+	case float64:
+		if v != float64(int(v)) {
+			return entry.Default, "", fmt.Errorf("type %T cannot be a severity unless it is a whole number", v)
+		}
+		strV := strconv.Itoa(int(v))
+		if severity, ok := m[strV]; ok {
+			return severity, strV, nil
+		}
+		return entry.Default, strV, nil
 	case string:
 		if severity, ok := m[strings.ToLower(v)]; ok {
 			return severity, v, nil

--- a/operator/helper/severity_test.go
+++ b/operator/helper/severity_test.go
@@ -144,6 +144,12 @@ func TestSeverityParser(t *testing.T) {
 			expected: entry.Error,
 		},
 		{
+			name:     "custom-float64",
+			sample:   float64(6),
+			mapping:  map[interface{}]interface{}{"error": 6},
+			expected: entry.Error,
+		},
+		{
 			name:     "mixed-list-int",
 			sample:   1234,
 			mapping:  map[interface{}]interface{}{"error": []interface{}{"NOOOOOOO", "this is bad", 1234}},


### PR DESCRIPTION
Severity parsing should support float64 values when they are whole numbers. Golang JSON parsing will consider any number a float64 unless it is unmarshalled to a struct using specific types (int, int64, float64, etc).

Trying to parse the `pri` field as a Severity will result in an "unsupported type float64" error.
```json
{
  "uid": 62,
  "time": 1617410898,
  "pri": 6,
  "tag": "pve-ha-lrm",
  "pid": 33690,
  "node": "pve-1",
  "user": "root@pam",
  "msg": "end task UPID:pve-1:0000839B:000C5C3F:6067BB15:qmshutdown:100:root@pam: OK"
}
```

Additional context:
- Stanza PR https://github.com/observIQ/stanza/pull/268
- Stanza Issue https://github.com/observIQ/stanza/issues/267