### PR TITLE
Make entry.Entry smaller by reordeing fields

### DIFF
--- a/entry/entry.go
+++ b/entry/entry.go
@@ -43,14 +43,14 @@ var now = getNow()
 // Entry is a flexible representation of log data associated with a timestamp.
 type Entry struct {
 	Timestamp    time.Time         `json:"timestamp"               yaml:"timestamp"`
-	Severity     Severity          `json:"severity"                yaml:"severity"`
-	SeverityText string            `json:"severity_text,omitempty" yaml:"severity_text,omitempty"`
+	Body         interface{}       `json:"body"                    yaml:"body"`
 	Attributes   map[string]string `json:"attributes,omitempty"    yaml:"attributes,omitempty"`
 	Resource     map[string]string `json:"resource,omitempty"      yaml:"resource,omitempty"`
-	Body         interface{}       `json:"body"                    yaml:"body"`
-	TraceId      []byte            `json:"trace_id,omitempty"      yaml:"trace_id,omitempty"`
+	SeverityText string            `json:"severity_text,omitempty" yaml:"severity_text,omitempty"`
 	SpanId       []byte            `json:"span_id,omitempty"       yaml:"span_id,omitempty"`
+	TraceId      []byte            `json:"trace_id,omitempty"      yaml:"trace_id,omitempty"`
 	TraceFlags   []byte            `json:"trace_flags,omitempty"   yaml:"trace_flags,omitempty"`
+	Severity     Severity          `json:"severity"                yaml:"severity"`
 }
 
 // New will create a new log entry with current timestamp and an empty body.

--- a/operator/builtin/output/stdout/stdout_test.go
+++ b/operator/builtin/output/stdout/stdout_test.go
@@ -56,6 +56,6 @@ func TestStdoutOperator(t *testing.T) {
 	marshalledTimestamp, err := json.Marshal(ts)
 	require.NoError(t, err)
 
-	expected := `{"timestamp":` + string(marshalledTimestamp) + `,"severity":0,"body":"test body"}` + "\n"
+	expected := `{"timestamp":` + string(marshalledTimestamp) + `,"body":"test body","severity":0}` + "\n"
 	require.Equal(t, expected, buf.String())
 }


### PR DESCRIPTION
Changes suggest by [fieldalignment](https://pkg.go.dev/golang.org/x/tools@v0.1.0/go/analysis/passes/fieldalignment/cmd/fieldalignment)

```
struct with 136 pointer bytes could be 128
```

Fixes: https://github.com/open-telemetry/opentelemetry-log-collection/issues/95