### PR TITLE
Move operator golden config testing into separate package

### DIFF
--- a/operator/builtin/input/file/config_test.go
+++ b/operator/builtin/input/file/config_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	cases := []operatortest.ConfigTestCase{
+	cases := []operatortest.ConfigUnmarshalTest{
 		{
 			Name:      "default",
 			ExpectErr: false,
@@ -507,7 +507,7 @@ func TestConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
+			tc.Run(t, defaultCfg())
 		})
 	}
 }

--- a/operator/builtin/input/file/config_test.go
+++ b/operator/builtin/input/file/config_test.go
@@ -15,116 +15,107 @@
 package file
 
 import (
-	"fmt"
-	"io/ioutil"
-	"path"
 	"testing"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper/operatortest"
 )
 
-type testCase struct {
-	name      string
-	expectErr bool
-	expect    *InputConfig
-}
-
 func TestConfig(t *testing.T) {
-	cases := []testCase{
+	cases := []operatortest.ConfigTestCase{
 		{
-			"default",
-			false,
-			defaultCfg(),
+			Name:      "default",
+			ExpectErr: false,
+			Expect:    defaultCfg(),
 		},
 		{
 
-			"extra_field",
-			false,
-			defaultCfg(),
+			Name:      "extra_field",
+			ExpectErr: false,
+			Expect:    defaultCfg(),
 		},
 		{
-			"id_custom",
-			false,
-			NewInputConfig("test_id"),
+			Name:      "id_custom",
+			ExpectErr: false,
+			Expect:    NewInputConfig("test_id"),
 		},
 		{
-			"include_one",
-			false,
-			func() *InputConfig {
+			Name:      "include_one",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "one.log")
 				return cfg
 			}(),
 		},
 		{
-			"include_multi",
-			false,
-			func() *InputConfig {
+			Name:      "include_multi",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "one.log", "two.log", "three.log")
 				return cfg
 			}(),
 		},
 		{
-			"include_glob",
-			false,
-			func() *InputConfig {
+			Name:      "include_glob",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "*.log")
 				return cfg
 			}(),
 		},
 		{
-			"include_glob_double_asterisk",
-			false,
-			func() *InputConfig {
+			Name:      "include_glob_double_asterisk",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "**.log")
 				return cfg
 			}(),
 		},
 		{
-			"include_glob_double_asterisk_nested",
-			false,
-			func() *InputConfig {
+			Name:      "include_glob_double_asterisk_nested",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "directory/**/*.log")
 				return cfg
 			}(),
 		},
 		{
-			"include_glob_double_asterisk_prefix",
-			false,
-			func() *InputConfig {
+			Name:      "include_glob_double_asterisk_prefix",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "**/directory/**/*.log")
 				return cfg
 			}(),
 		},
 		{
-			"include_inline",
-			false,
-			func() *InputConfig {
+			Name:      "include_inline",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "a.log", "b.log")
 				return cfg
 			}(),
 		},
 		{
-			"include_invalid",
-			true,
-			nil,
+			Name:      "include_invalid",
+			ExpectErr: true,
+			Expect:    nil,
 		},
 		{
-			"exclude_one",
-			false,
-			func() *InputConfig {
+			Name:      "exclude_one",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "*.log")
 				cfg.Exclude = append(cfg.Exclude, "one.log")
@@ -132,9 +123,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"exclude_multi",
-			false,
-			func() *InputConfig {
+			Name:      "exclude_multi",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "*.log")
 				cfg.Exclude = append(cfg.Exclude, "one.log", "two.log", "three.log")
@@ -142,9 +133,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"exclude_glob",
-			false,
-			func() *InputConfig {
+			Name:      "exclude_glob",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "*.log")
 				cfg.Exclude = append(cfg.Exclude, "not*.log")
@@ -152,9 +143,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"exclude_glob_double_asterisk",
-			false,
-			func() *InputConfig {
+			Name:      "exclude_glob_double_asterisk",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "*.log")
 				cfg.Exclude = append(cfg.Exclude, "not**.log")
@@ -162,9 +153,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"exclude_glob_double_asterisk_nested",
-			false,
-			func() *InputConfig {
+			Name:      "exclude_glob_double_asterisk_nested",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "*.log")
 				cfg.Exclude = append(cfg.Exclude, "directory/**/not*.log")
@@ -172,9 +163,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"exclude_glob_double_asterisk_prefix",
-			false,
-			func() *InputConfig {
+			Name:      "exclude_glob_double_asterisk_prefix",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "*.log")
 				cfg.Exclude = append(cfg.Exclude, "**/directory/**/not*.log")
@@ -182,9 +173,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"exclude_inline",
-			false,
-			func() *InputConfig {
+			Name:      "exclude_inline",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "*.log")
 				cfg.Exclude = append(cfg.Exclude, "a.log", "b.log")
@@ -192,104 +183,104 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"exclude_invalid",
-			true,
-			nil,
+			Name:      "exclude_invalid",
+			ExpectErr: true,
+			Expect:    nil,
 		},
 		{
-			"poll_interval_no_units",
-			false,
-			func() *InputConfig {
+			Name:      "poll_interval_no_units",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.PollInterval = helper.NewDuration(time.Second)
 				return cfg
 			}(),
 		},
 		{
-			"poll_interval_1s",
-			false,
-			func() *InputConfig {
+			Name:      "poll_interval_1s",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.PollInterval = helper.NewDuration(time.Second)
 				return cfg
 			}(),
 		},
 		{
-			"poll_interval_1ms",
-			false,
-			func() *InputConfig {
+			Name:      "poll_interval_1ms",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.PollInterval = helper.NewDuration(time.Millisecond)
 				return cfg
 			}(),
 		},
 		{
-			"poll_interval_1000ms",
-			false,
-			func() *InputConfig {
+			Name:      "poll_interval_1000ms",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.PollInterval = helper.NewDuration(time.Second)
 				return cfg
 			}(),
 		},
 		{
-			"fingerprint_size_no_units",
-			false,
-			func() *InputConfig {
+			Name:      "fingerprint_size_no_units",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.FingerprintSize = helper.ByteSize(1000)
 				return cfg
 			}(),
 		},
 		{
-			"fingerprint_size_1kb_lower",
-			false,
-			func() *InputConfig {
+			Name:      "fingerprint_size_1kb_lower",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.FingerprintSize = helper.ByteSize(1000)
 				return cfg
 			}(),
 		},
 		{
-			"fingerprint_size_1KB",
-			false,
-			func() *InputConfig {
+			Name:      "fingerprint_size_1KB",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.FingerprintSize = helper.ByteSize(1000)
 				return cfg
 			}(),
 		},
 		{
-			"fingerprint_size_1kib_lower",
-			false,
-			func() *InputConfig {
+			Name:      "fingerprint_size_1kib_lower",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.FingerprintSize = helper.ByteSize(1024)
 				return cfg
 			}(),
 		},
 		{
-			"fingerprint_size_1KiB",
-			false,
-			func() *InputConfig {
+			Name:      "fingerprint_size_1KiB",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.FingerprintSize = helper.ByteSize(1024)
 				return cfg
 			}(),
 		},
 		{
-			"fingerprint_size_float",
-			false,
-			func() *InputConfig {
+			Name:      "fingerprint_size_float",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.FingerprintSize = helper.ByteSize(1100)
 				return cfg
 			}(),
 		},
 		{
-			"include_file_name_lower",
-			false,
-			func() *InputConfig {
+			Name:      "include_file_name_lower",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "one.log")
 				cfg.IncludeFileName = true
@@ -297,9 +288,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"include_file_name_upper",
-			false,
-			func() *InputConfig {
+			Name:      "include_file_name_upper",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "one.log")
 				cfg.IncludeFileName = true
@@ -307,9 +298,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"include_file_name_on",
-			false,
-			func() *InputConfig {
+			Name:      "include_file_name_on",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "one.log")
 				cfg.IncludeFileName = true
@@ -317,9 +308,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"include_file_name_yes",
-			false,
-			func() *InputConfig {
+			Name:      "include_file_name_yes",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "one.log")
 				cfg.IncludeFileName = true
@@ -327,9 +318,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"include_file_path_lower",
-			false,
-			func() *InputConfig {
+			Name:      "include_file_path_lower",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "one.log")
 				cfg.IncludeFilePath = true
@@ -337,9 +328,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"include_file_path_upper",
-			false,
-			func() *InputConfig {
+			Name:      "include_file_path_upper",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "one.log")
 				cfg.IncludeFilePath = true
@@ -347,9 +338,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"include_file_path_on",
-			false,
-			func() *InputConfig {
+			Name:      "include_file_path_on",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "one.log")
 				cfg.IncludeFilePath = true
@@ -357,9 +348,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"include_file_path_yes",
-			false,
-			func() *InputConfig {
+			Name:      "include_file_path_yes",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "one.log")
 				cfg.IncludeFilePath = true
@@ -367,9 +358,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"include_file_path_off",
-			false,
-			func() *InputConfig {
+			Name:      "include_file_path_off",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "one.log")
 				cfg.IncludeFilePath = false
@@ -377,9 +368,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"include_file_path_no",
-			false,
-			func() *InputConfig {
+			Name:      "include_file_path_no",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Include = append(cfg.Include, "one.log")
 				cfg.IncludeFilePath = false
@@ -387,14 +378,14 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"include_file_path_nonbool",
-			true,
-			nil,
+			Name:      "include_file_path_nonbool",
+			ExpectErr: true,
+			Expect:    nil,
 		},
 		{
-			"multiline_line_start_string",
-			false,
-			func() *InputConfig {
+			Name:      "multiline_line_start_string",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				newMulti := new(MultilineConfig)
 				newMulti.LineStartPattern = "Start"
@@ -403,9 +394,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"multiline_line_start_special",
-			false,
-			func() *InputConfig {
+			Name:      "multiline_line_start_special",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				newMulti := new(MultilineConfig)
 				newMulti.LineStartPattern = "%"
@@ -414,9 +405,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"multiline_line_end_string",
-			false,
-			func() *InputConfig {
+			Name:      "multiline_line_end_string",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				newMulti := new(MultilineConfig)
 				newMulti.LineEndPattern = "Start"
@@ -425,9 +416,9 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"multiline_line_end_special",
-			false,
-			func() *InputConfig {
+			Name:      "multiline_line_end_special",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				newMulti := new(MultilineConfig)
 				newMulti.LineEndPattern = "%"
@@ -436,82 +427,77 @@ func TestConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"multiline_random",
-			true,
-			nil,
+			Name:      "multiline_random",
+			ExpectErr: true,
+			Expect:    nil,
 		},
 		{
-			"start_at_string",
-			false,
-			func() *InputConfig {
+			Name:      "start_at_string",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.StartAt = "beginning"
 				return cfg
 			}(),
 		},
 		{
-			"max_concurrent_large",
-			false,
-			func() *InputConfig {
+			Name:      "max_concurrent_large",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.MaxConcurrentFiles = 9223372036854775807
 				return cfg
 			}(),
 		},
 		{
-			"max_log_size_mib_lower",
-			false,
-			func() *InputConfig {
+			Name:      "max_log_size_mib_lower",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.MaxLogSize = helper.ByteSize(1048576)
 				return cfg
 			}(),
 		},
 		{
-			"max_log_size_mib_upper",
-			false,
-			func() *InputConfig {
+			Name:      "max_log_size_mib_upper",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.MaxLogSize = helper.ByteSize(1048576)
 				return cfg
 			}(),
 		},
 		{
-			"max_log_size_mb_upper",
-			false,
-			func() *InputConfig {
+			Name:      "max_log_size_mb_upper",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.MaxLogSize = helper.ByteSize(1048576)
 				return cfg
 			}(),
 		},
 		{
-			"max_log_size_mb_lower",
-			false,
-			func() *InputConfig {
+			Name:      "max_log_size_mb_lower",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.MaxLogSize = helper.ByteSize(1048576)
 				return cfg
 			}(),
 		},
 		{
-			"max_log_size_invalid_unit",
-			true,
-			nil,
-		},
-		{
-			"encoding_lower",
-			false,
-			func() *InputConfig {
+			Name:      "encoding_lower",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Encoding = "utf-16le"
 				return cfg
 			}(),
 		},
 		{
-			"encoding_upper",
-			false,
-			func() *InputConfig {
+			Name:      "encoding_upper",
+			ExpectErr: false,
+			Expect: func() *InputConfig {
 				cfg := defaultCfg()
 				cfg.Encoding = "UTF-16lE"
 				return cfg
@@ -520,59 +506,10 @@ func TestConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			cfgFromYaml, yamlErr := configFromFileViaYaml(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			cfgFromMapstructure, mapErr := configFromFileViaMapstructure(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			if tc.expectErr {
-				require.Error(t, yamlErr)
-				require.Error(t, mapErr)
-			} else {
-				require.NoError(t, yamlErr)
-				require.Equal(t, tc.expect, cfgFromYaml)
-				require.NoError(t, mapErr)
-				require.Equal(t, tc.expect, cfgFromMapstructure)
-			}
+		t.Run(tc.Name, func(t *testing.T) {
+			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
 		})
 	}
-}
-
-func configFromFileViaYaml(file string) (*InputConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	config := defaultCfg()
-	if err := yaml.Unmarshal(bytes, config); err != nil {
-		return nil, fmt.Errorf("failed to read config file as yaml: %s", err)
-	}
-
-	return config, nil
-}
-
-func configFromFileViaMapstructure(file string) (*InputConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	raw := map[string]interface{}{}
-
-	if err := yaml.Unmarshal(bytes, raw); err != nil {
-		return nil, fmt.Errorf("failed to read data from yaml: %s", err)
-	}
-
-	cfg := defaultCfg()
-	dc := &mapstructure.DecoderConfig{Result: cfg, DecodeHook: helper.JSONUnmarshalerHook()}
-	ms, err := mapstructure.NewDecoder(dc)
-	if err != nil {
-		return nil, err
-	}
-	err = ms.Decode(raw)
-	if err != nil {
-		return nil, err
-	}
-	return cfg, nil
 }
 
 func defaultCfg() *InputConfig {

--- a/operator/builtin/parser/json/config_test.go
+++ b/operator/builtin/parser/json/config_test.go
@@ -14,62 +14,46 @@
 package json
 
 import (
-	"fmt"
-	"io/ioutil"
-	"path"
 	"testing"
-
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper/operatortest"
 )
 
-type testCase struct {
-	name      string
-	expectErr bool
-	expect    *JSONParserConfig
-}
-
 func TestJSONParserConfig(t *testing.T) {
-	cases := []testCase{
+	cases := []operatortest.ConfigTestCase{
 		{
-			"default",
-			false,
-			defaultCfg(),
+			Name:   "default",
+			Expect: defaultCfg(),
 		},
 		{
-			"parse_from_simple",
-			false,
-			func() *JSONParserConfig {
+			Name: "parse_from_simple",
+			Expect: func() *JSONParserConfig {
 				cfg := defaultCfg()
 				cfg.ParseFrom = entry.NewBodyField("from")
 				return cfg
 			}(),
 		},
 		{
-			"parse_to_simple",
-			false,
-			func() *JSONParserConfig {
+			Name: "parse_to_simple",
+			Expect: func() *JSONParserConfig {
 				cfg := defaultCfg()
 				cfg.ParseTo = entry.NewBodyField("log")
 				return cfg
 			}(),
 		},
 		{
-			"on_error_drop",
-			false,
-			func() *JSONParserConfig {
+			Name: "on_error_drop",
+			Expect: func() *JSONParserConfig {
 				cfg := defaultCfg()
 				cfg.OnError = "drop"
 				return cfg
 			}(),
 		},
 		{
-			"timestamp",
-			false,
-			func() *JSONParserConfig {
+			Name: "timestamp",
+			Expect: func() *JSONParserConfig {
 				cfg := defaultCfg()
 				parseField := entry.NewBodyField("timestamp_field")
 				newTime := helper.TimeParser{
@@ -82,9 +66,8 @@ func TestJSONParserConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"severity",
-			false,
-			func() *JSONParserConfig {
+			Name: "severity",
+			Expect: func() *JSONParserConfig {
 				cfg := defaultCfg()
 				parseField := entry.NewBodyField("severity_field")
 				severityField := helper.NewSeverityParserConfig()
@@ -101,9 +84,8 @@ func TestJSONParserConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"preserve_to",
-			false,
-			func() *JSONParserConfig {
+			Name: "preserve_to",
+			Expect: func() *JSONParserConfig {
 				cfg := defaultCfg()
 				preserve := entry.NewBodyField("aField")
 				cfg.PreserveTo = &preserve
@@ -113,59 +95,10 @@ func TestJSONParserConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run("yaml/"+tc.name, func(t *testing.T) {
-			cfgFromYaml, yamlErr := configFromFileViaYaml(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			if tc.expectErr {
-				require.Error(t, yamlErr)
-			} else {
-				require.NoError(t, yamlErr)
-				require.Equal(t, tc.expect, cfgFromYaml)
-			}
-		})
-		t.Run("mapstructure/"+tc.name, func(t *testing.T) {
-			cfgFromMapstructure := defaultCfg()
-			mapErr := configFromFileViaMapstructure(
-				path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)),
-				cfgFromMapstructure,
-			)
-			if tc.expectErr {
-				require.Error(t, mapErr)
-			} else {
-				require.NoError(t, mapErr)
-				require.Equal(t, tc.expect, cfgFromMapstructure)
-			}
+		t.Run(tc.Name, func(t *testing.T) {
+			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
 		})
 	}
-}
-
-func configFromFileViaYaml(file string) (*JSONParserConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	config := defaultCfg()
-	if err := yaml.Unmarshal(bytes, config); err != nil {
-		return nil, fmt.Errorf("failed to read config file as yaml: %s", err)
-	}
-
-	return config, nil
-}
-
-func configFromFileViaMapstructure(file string, result *JSONParserConfig) error {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return fmt.Errorf("could not find config file: %s", err)
-	}
-
-	raw := map[string]interface{}{}
-
-	if err := yaml.Unmarshal(bytes, raw); err != nil {
-		return fmt.Errorf("failed to read data from yaml: %s", err)
-	}
-
-	err = helper.UnmarshalMapstructure(raw, result)
-	return err
 }
 
 func defaultCfg() *JSONParserConfig {

--- a/operator/builtin/parser/json/config_test.go
+++ b/operator/builtin/parser/json/config_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestJSONParserConfig(t *testing.T) {
-	cases := []operatortest.ConfigTestCase{
+	cases := []operatortest.ConfigUnmarshalTest{
 		{
 			Name:   "default",
 			Expect: defaultCfg(),
@@ -96,7 +96,7 @@ func TestJSONParserConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
+			tc.Run(t, defaultCfg())
 		})
 	}
 }

--- a/operator/builtin/parser/regex/config_test.go
+++ b/operator/builtin/parser/regex/config_test.go
@@ -14,62 +14,46 @@
 package regex
 
 import (
-	"fmt"
-	"io/ioutil"
-	"path"
 	"testing"
-
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper/operatortest"
 )
 
-type testCase struct {
-	name      string
-	expectErr bool
-	expect    *RegexParserConfig
-}
-
 func TestRegexParserGoldenConfig(t *testing.T) {
-	cases := []testCase{
+	cases := []operatortest.ConfigTestCase{
 		{
-			"default",
-			false,
-			defaultCfg(),
+			Name:   "default",
+			Expect: defaultCfg(),
 		},
 		{
-			"parse_from_simple",
-			false,
-			func() *RegexParserConfig {
+			Name: "parse_from_simple",
+			Expect: func() *RegexParserConfig {
 				cfg := defaultCfg()
 				cfg.ParseFrom = entry.NewBodyField("from")
 				return cfg
 			}(),
 		},
 		{
-			"parse_to_simple",
-			false,
-			func() *RegexParserConfig {
+			Name: "parse_to_simple",
+			Expect: func() *RegexParserConfig {
 				cfg := defaultCfg()
 				cfg.ParseTo = entry.NewBodyField("log")
 				return cfg
 			}(),
 		},
 		{
-			"on_error_drop",
-			false,
-			func() *RegexParserConfig {
+			Name: "on_error_drop",
+			Expect: func() *RegexParserConfig {
 				cfg := defaultCfg()
 				cfg.OnError = "drop"
 				return cfg
 			}(),
 		},
 		{
-			"timestamp",
-			false,
-			func() *RegexParserConfig {
+			Name: "timestamp",
+			Expect: func() *RegexParserConfig {
 				cfg := defaultCfg()
 				parseField := entry.NewBodyField("timestamp_field")
 				newTime := helper.TimeParser{
@@ -82,9 +66,8 @@ func TestRegexParserGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"severity",
-			false,
-			func() *RegexParserConfig {
+			Name: "severity",
+			Expect: func() *RegexParserConfig {
 				cfg := defaultCfg()
 				parseField := entry.NewBodyField("severity_field")
 				severityField := helper.NewSeverityParserConfig()
@@ -101,9 +84,8 @@ func TestRegexParserGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"preserve_to",
-			false,
-			func() *RegexParserConfig {
+			Name: "preserve_to",
+			Expect: func() *RegexParserConfig {
 				cfg := defaultCfg()
 				preserve := entry.NewBodyField("aField")
 				cfg.PreserveTo = &preserve
@@ -111,9 +93,8 @@ func TestRegexParserGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"regex",
-			false,
-			func() *RegexParserConfig {
+			Name: "regex",
+			Expect: func() *RegexParserConfig {
 				cfg := defaultCfg()
 				cfg.Regex = "^Host=(?P<host>[^,]+), Type=(?P<type>.*)$"
 				return cfg
@@ -122,59 +103,10 @@ func TestRegexParserGoldenConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run("yaml/"+tc.name, func(t *testing.T) {
-			cfgFromYaml, yamlErr := configFromFileViaYaml(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			if tc.expectErr {
-				require.Error(t, yamlErr)
-			} else {
-				require.NoError(t, yamlErr)
-				require.Equal(t, tc.expect, cfgFromYaml)
-			}
-		})
-		t.Run("mapstructure/"+tc.name, func(t *testing.T) {
-			cfgFromMapstructure := defaultCfg()
-			mapErr := configFromFileViaMapstructure(
-				path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)),
-				cfgFromMapstructure,
-			)
-			if tc.expectErr {
-				require.Error(t, mapErr)
-			} else {
-				require.NoError(t, mapErr)
-				require.Equal(t, tc.expect, cfgFromMapstructure)
-			}
+		t.Run(tc.Name, func(t *testing.T) {
+			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
 		})
 	}
-}
-
-func configFromFileViaYaml(file string) (*RegexParserConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	config := defaultCfg()
-	if err := yaml.Unmarshal(bytes, config); err != nil {
-		return nil, fmt.Errorf("failed to read config file as yaml: %s", err)
-	}
-
-	return config, nil
-}
-
-func configFromFileViaMapstructure(file string, result *RegexParserConfig) error {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return fmt.Errorf("could not find config file: %s", err)
-	}
-
-	raw := map[string]interface{}{}
-
-	if err := yaml.Unmarshal(bytes, raw); err != nil {
-		return fmt.Errorf("failed to read data from yaml: %s", err)
-	}
-
-	err = helper.UnmarshalMapstructure(raw, result)
-	return err
 }
 
 func defaultCfg() *RegexParserConfig {

--- a/operator/builtin/parser/regex/config_test.go
+++ b/operator/builtin/parser/regex/config_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestRegexParserGoldenConfig(t *testing.T) {
-	cases := []operatortest.ConfigTestCase{
+	cases := []operatortest.ConfigUnmarshalTest{
 		{
 			Name:   "default",
 			Expect: defaultCfg(),
@@ -104,7 +104,7 @@ func TestRegexParserGoldenConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
+			tc.Run(t, defaultCfg())
 		})
 	}
 }

--- a/operator/builtin/transformer/add/config_test.go
+++ b/operator/builtin/transformer/add/config_test.go
@@ -15,26 +15,17 @@ package add
 // limitations under the License.
 
 import (
-	"fmt"
-	"path"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper/operatortest"
 )
 
-type configTestCase struct {
-	name   string
-	expect *AddOperatorConfig
-}
-
 func TestGoldenConfig(t *testing.T) {
-	cases := []configTestCase{
+	cases := []operatortest.ConfigTestCase{
 		{
-			"add_value",
-			func() *AddOperatorConfig {
+			Name: "add_value",
+			Expect: func() *AddOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Field = entry.NewBodyField("new")
 				cfg.Value = "randomMessage"
@@ -42,8 +33,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"add_expr",
-			func() *AddOperatorConfig {
+			Name: "add_expr",
+			Expect: func() *AddOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Field = entry.NewBodyField("new")
 				cfg.Value = `EXPR($.key + "_suffix")`
@@ -51,8 +42,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"add_nest",
-			func() *AddOperatorConfig {
+			Name: "add_nest",
+			Expect: func() *AddOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Field = entry.NewBodyField("new")
 				cfg.Value = map[interface{}]interface{}{
@@ -62,8 +53,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"add_attribute",
-			func() *AddOperatorConfig {
+			Name: "add_attribute",
+			Expect: func() *AddOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Field = entry.NewAttributeField("new")
 				cfg.Value = "newVal"
@@ -71,8 +62,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"add_resource",
-			func() *AddOperatorConfig {
+			Name: "add_resource",
+			Expect: func() *AddOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Field = entry.NewResourceField("new")
 				cfg.Value = "newVal"
@@ -80,8 +71,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"add_resource_expr",
-			func() *AddOperatorConfig {
+			Name: "add_resource_expr",
+			Expect: func() *AddOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Field = entry.NewResourceField("new")
 				cfg.Value = `EXPR($.key + "_suffix")`
@@ -89,8 +80,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"add_array_to_body",
-			func() *AddOperatorConfig {
+			Name: "add_array_to_body",
+			Expect: func() *AddOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Field = entry.NewBodyField("new")
 				cfg.Value = []interface{}{1, 2, 3, 4}
@@ -99,13 +90,8 @@ func TestGoldenConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			cfgFromYaml, yamlErr := operatortest.ConfigFromFileViaYaml(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)), defaultCfg())
-			cfgFromMapstructure, mapErr := operatortest.ConfigFromFileViaMapstructure(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)), defaultCfg())
-			require.NoError(t, yamlErr)
-			require.Equal(t, tc.expect, cfgFromYaml)
-			require.NoError(t, mapErr)
-			require.Equal(t, tc.expect, cfgFromMapstructure)
+		t.Run(tc.Name, func(t *testing.T) {
+			operatortest.RunGoldenConfigTest(defaultCfg(), t, tc)
 		})
 	}
 }

--- a/operator/builtin/transformer/add/config_test.go
+++ b/operator/builtin/transformer/add/config_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestGoldenConfig(t *testing.T) {
-	cases := []operatortest.ConfigTestCase{
+	cases := []operatortest.ConfigUnmarshalTest{
 		{
 			Name: "add_value",
 			Expect: func() *AddOperatorConfig {
@@ -91,7 +91,7 @@ func TestGoldenConfig(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
+			tc.Run(t, defaultCfg())
 		})
 	}
 }

--- a/operator/builtin/transformer/add/config_test.go
+++ b/operator/builtin/transformer/add/config_test.go
@@ -91,7 +91,7 @@ func TestGoldenConfig(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			operatortest.RunGoldenConfigTest(defaultCfg(), t, tc)
+			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
 		})
 	}
 }

--- a/operator/builtin/transformer/copy/config_test.go
+++ b/operator/builtin/transformer/copy/config_test.go
@@ -14,30 +14,18 @@
 package copy
 
 import (
-	"fmt"
-	"io/ioutil"
-	"path"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
-
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
-	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper/operatortest"
 )
-
-type configTestCase struct {
-	name   string
-	expect *CopyOperatorConfig
-}
 
 // test unmarshalling of values into config struct
 func TestGoldenConfig(t *testing.T) {
-	cases := []configTestCase{
+	cases := []operatortest.ConfigTestCase{
 		{
-			"body_to_body",
-			func() *CopyOperatorConfig {
+			Name: "body_to_body",
+			Expect: func() *CopyOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewBodyField("key")
 				cfg.To = entry.NewBodyField("key2")
@@ -45,8 +33,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"body_to_attribute",
-			func() *CopyOperatorConfig {
+			Name: "body_to_attribute",
+			Expect: func() *CopyOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewBodyField("key")
 				cfg.To = entry.NewAttributeField("key2")
@@ -54,8 +42,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"attribute_to_resource",
-			func() *CopyOperatorConfig {
+			Name: "attribute_to_resource",
+			Expect: func() *CopyOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewAttributeField("key")
 				cfg.To = entry.NewResourceField("key2")
@@ -63,8 +51,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"attribute_to_body",
-			func() *CopyOperatorConfig {
+			Name: "attribute_to_body",
+			Expect: func() *CopyOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewAttributeField("key")
 				cfg.To = entry.NewBodyField("key2")
@@ -73,54 +61,10 @@ func TestGoldenConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			cfgFromYaml, yamlErr := configFromFileViaYaml(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			cfgFromMapstructure, mapErr := configFromFileViaMapstructure(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			require.NoError(t, yamlErr)
-			require.Equal(t, tc.expect, cfgFromYaml)
-			require.NoError(t, mapErr)
-			require.Equal(t, tc.expect, cfgFromMapstructure)
+		t.Run(tc.Name, func(t *testing.T) {
+			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
 		})
 	}
-}
-
-func configFromFileViaYaml(file string) (*CopyOperatorConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	config := defaultCfg()
-	if err := yaml.Unmarshal(bytes, config); err != nil {
-		return nil, fmt.Errorf("failed to read config file as yaml: %s", err)
-	}
-
-	return config, nil
-}
-
-func configFromFileViaMapstructure(file string) (*CopyOperatorConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	raw := map[string]interface{}{}
-
-	if err := yaml.Unmarshal(bytes, raw); err != nil {
-		return nil, fmt.Errorf("failed to read data from yaml: %s", err)
-	}
-
-	cfg := defaultCfg()
-	dc := &mapstructure.DecoderConfig{Result: cfg, DecodeHook: helper.JSONUnmarshalerHook()}
-	ms, err := mapstructure.NewDecoder(dc)
-	if err != nil {
-		return nil, err
-	}
-	err = ms.Decode(raw)
-	if err != nil {
-		return nil, err
-	}
-	return cfg, nil
 }
 
 func defaultCfg() *CopyOperatorConfig {

--- a/operator/builtin/transformer/copy/config_test.go
+++ b/operator/builtin/transformer/copy/config_test.go
@@ -22,7 +22,7 @@ import (
 
 // test unmarshalling of values into config struct
 func TestGoldenConfig(t *testing.T) {
-	cases := []operatortest.ConfigTestCase{
+	cases := []operatortest.ConfigUnmarshalTest{
 		{
 			Name: "body_to_body",
 			Expect: func() *CopyOperatorConfig {
@@ -62,7 +62,7 @@ func TestGoldenConfig(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
+			tc.Run(t, defaultCfg())
 		})
 	}
 }

--- a/operator/builtin/transformer/metadata/config_test.go
+++ b/operator/builtin/transformer/metadata/config_test.go
@@ -14,52 +14,37 @@
 package metadata
 
 import (
-	"fmt"
-	"io/ioutil"
-	"path"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
-
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper/operatortest"
 )
 
-type testCase struct {
-	name      string
-	expectErr bool
-	expect    *MetadataOperatorConfig
-}
-
 func TestMetaDataGoldenConfig(t *testing.T) {
-	cases := []testCase{
+	cases := []operatortest.ConfigTestCase{
 		{
-			"default",
-			false,
-			defaultCfg(),
+			Name:   "default",
+			Expect: defaultCfg(),
 		},
 		{
-			"id",
-			false,
-			func() *MetadataOperatorConfig {
+			Name: "id",
+			Expect: func() *MetadataOperatorConfig {
 				cfg := defaultCfg()
 				cfg.OperatorID = "newName"
 				return cfg
 			}(),
 		},
 		{
-			"output",
-			false,
-			func() *MetadataOperatorConfig {
+			Name: "output",
+			Expect: func() *MetadataOperatorConfig {
 				cfg := defaultCfg()
 				cfg.OutputIDs = append(cfg.OutputIDs, "nextOperator")
 				return cfg
 			}(),
 		},
 		{
-			"attributes_single",
-			false,
-			func() *MetadataOperatorConfig {
+			Name: "attributes_single",
+			Expect: func() *MetadataOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Attributes = map[string]helper.ExprStringConfig{
 					"key1": `val1`,
@@ -68,9 +53,8 @@ func TestMetaDataGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"attributes_multi",
-			false,
-			func() *MetadataOperatorConfig {
+			Name: "attributes_multi",
+			Expect: func() *MetadataOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Attributes = map[string]helper.ExprStringConfig{
 					"key1": `val1`,
@@ -81,9 +65,8 @@ func TestMetaDataGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"resource_single",
-			false,
-			func() *MetadataOperatorConfig {
+			Name: "resource_single",
+			Expect: func() *MetadataOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Resource = map[string]helper.ExprStringConfig{
 					"key1": `val1`,
@@ -92,9 +75,8 @@ func TestMetaDataGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"resource_multi",
-			false,
-			func() *MetadataOperatorConfig {
+			Name: "resource_multi",
+			Expect: func() *MetadataOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Resource = map[string]helper.ExprStringConfig{
 					"key1": `val1`,
@@ -105,9 +87,8 @@ func TestMetaDataGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"on_error",
-			false,
-			func() *MetadataOperatorConfig {
+			Name: "on_error",
+			Expect: func() *MetadataOperatorConfig {
 				cfg := defaultCfg()
 				cfg.OnError = "drop"
 				return cfg
@@ -116,59 +97,10 @@ func TestMetaDataGoldenConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run("yaml/"+tc.name, func(t *testing.T) {
-			cfgFromYaml, yamlErr := configFromFileViaYaml(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			if tc.expectErr {
-				require.Error(t, yamlErr)
-			} else {
-				require.NoError(t, yamlErr)
-				require.Equal(t, tc.expect, cfgFromYaml)
-			}
-		})
-		t.Run("mapstructure/"+tc.name, func(t *testing.T) {
-			cfgFromMapstructure := defaultCfg()
-			mapErr := configFromFileViaMapstructure(
-				path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)),
-				cfgFromMapstructure,
-			)
-			if tc.expectErr {
-				require.Error(t, mapErr)
-			} else {
-				require.NoError(t, mapErr)
-				require.Equal(t, tc.expect, cfgFromMapstructure)
-			}
+		t.Run(tc.Name, func(t *testing.T) {
+			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
 		})
 	}
-}
-
-func configFromFileViaYaml(file string) (*MetadataOperatorConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	config := defaultCfg()
-	if err := yaml.Unmarshal(bytes, config); err != nil {
-		return nil, fmt.Errorf("failed to read config file as yaml: %s", err)
-	}
-
-	return config, nil
-}
-
-func configFromFileViaMapstructure(file string, result *MetadataOperatorConfig) error {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return fmt.Errorf("could not find config file: %s", err)
-	}
-
-	raw := map[string]interface{}{}
-
-	if err := yaml.Unmarshal(bytes, raw); err != nil {
-		return fmt.Errorf("failed to read data from yaml: %s", err)
-	}
-
-	err = helper.UnmarshalMapstructure(raw, result)
-	return err
 }
 
 func defaultCfg() *MetadataOperatorConfig {

--- a/operator/builtin/transformer/metadata/config_test.go
+++ b/operator/builtin/transformer/metadata/config_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestMetaDataGoldenConfig(t *testing.T) {
-	cases := []operatortest.ConfigTestCase{
+	cases := []operatortest.ConfigUnmarshalTest{
 		{
 			Name:   "default",
 			Expect: defaultCfg(),
@@ -98,7 +98,7 @@ func TestMetaDataGoldenConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
+			tc.Run(t, defaultCfg())
 		})
 	}
 }

--- a/operator/builtin/transformer/move/config_test.go
+++ b/operator/builtin/transformer/move/config_test.go
@@ -23,7 +23,7 @@ import (
 
 // test unmarshalling of values into config struct
 func TestGoldenConfig(t *testing.T) {
-	cases := []operatortest.ConfigTestCase{
+	cases := []operatortest.ConfigUnmarshalTest{
 		{
 			Name: "MoveBodyToBody",
 			Expect: func() *MoveOperatorConfig {
@@ -162,7 +162,7 @@ func TestGoldenConfig(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
+			tc.Run(t, defaultCfg())
 		})
 	}
 }

--- a/operator/builtin/transformer/move/config_test.go
+++ b/operator/builtin/transformer/move/config_test.go
@@ -15,30 +15,18 @@ package move
 // limitations under the License.
 
 import (
-	"fmt"
-	"io/ioutil"
-	"path"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
-
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
-	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper/operatortest"
 )
-
-type configTestCase struct {
-	name   string
-	expect *MoveOperatorConfig
-}
 
 // test unmarshalling of values into config struct
 func TestGoldenConfig(t *testing.T) {
-	cases := []configTestCase{
+	cases := []operatortest.ConfigTestCase{
 		{
-			"MoveBodyToBody",
-			func() *MoveOperatorConfig {
+			Name: "MoveBodyToBody",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewBodyField("key")
 				cfg.To = entry.NewBodyField("new")
@@ -46,8 +34,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"MoveBodyToAttribute",
-			func() *MoveOperatorConfig {
+			Name: "MoveBodyToAttribute",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewBodyField("key")
 				cfg.To = entry.NewAttributeField("new")
@@ -55,8 +43,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"MoveAttributeToBody",
-			func() *MoveOperatorConfig {
+			Name: "MoveAttributeToBody",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewAttributeField("new")
 				cfg.To = entry.NewBodyField("new")
@@ -64,8 +52,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"MoveAttributeToResource",
-			func() *MoveOperatorConfig {
+			Name: "MoveAttributeToResource",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewAttributeField("new")
 				cfg.To = entry.NewResourceField("new")
@@ -73,8 +61,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"MoveResourceToAttribute",
-			func() *MoveOperatorConfig {
+			Name: "MoveResourceToAttribute",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewResourceField("new")
 				cfg.To = entry.NewAttributeField("new")
@@ -82,8 +70,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"MoveNest",
-			func() *MoveOperatorConfig {
+			Name: "MoveNest",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewBodyField("nested")
 				cfg.To = entry.NewBodyField("NewNested")
@@ -91,8 +79,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"MoveFromNestedObj",
-			func() *MoveOperatorConfig {
+			Name: "MoveFromNestedObj",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewBodyField("nested", "nestedkey")
 				cfg.To = entry.NewBodyField("unnestedkey")
@@ -100,8 +88,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"MoveToNestedObj",
-			func() *MoveOperatorConfig {
+			Name: "MoveToNestedObj",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewBodyField("newnestedkey")
 				cfg.To = entry.NewBodyField("nested", "newnestedkey")
@@ -109,8 +97,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"MoveDoubleNestedObj",
-			func() *MoveOperatorConfig {
+			Name: "MoveDoubleNestedObj",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewBodyField("nested", "nested2")
 				cfg.To = entry.NewBodyField("nested2")
@@ -118,8 +106,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"MoveNestToResource",
-			func() *MoveOperatorConfig {
+			Name: "MoveNestToResource",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewBodyField("nested")
 				cfg.To = entry.NewResourceField("NewNested")
@@ -127,8 +115,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"MoveNestToAttribute",
-			func() *MoveOperatorConfig {
+			Name: "MoveNestToAttribute",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewBodyField("nested")
 				cfg.To = entry.NewAttributeField("NewNested")
@@ -136,8 +124,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"ImplicitBodyFrom",
-			func() *MoveOperatorConfig {
+			Name: "ImplicitBodyFrom",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewBodyField("implicitkey")
 				cfg.To = entry.NewAttributeField("new")
@@ -145,8 +133,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"ImplicitBodyTo",
-			func() *MoveOperatorConfig {
+			Name: "ImplicitBodyTo",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewAttributeField("new")
 				cfg.To = entry.NewBodyField("implicitkey")
@@ -154,8 +142,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"ImplicitNestedKey",
-			func() *MoveOperatorConfig {
+			Name: "ImplicitNestedKey",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewAttributeField("new")
 				cfg.To = entry.NewBodyField("key", "key2")
@@ -163,8 +151,8 @@ func TestGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"ReplaceBody",
-			func() *MoveOperatorConfig {
+			Name: "ReplaceBody",
+			Expect: func() *MoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.From = entry.NewBodyField("nested")
 				cfg.To = entry.NewBodyField()
@@ -173,54 +161,10 @@ func TestGoldenConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			cfgFromYaml, yamlErr := configFromFileViaYaml(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			cfgFromMapstructure, mapErr := configFromFileViaMapstructure(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			require.NoError(t, yamlErr)
-			require.Equal(t, tc.expect, cfgFromYaml)
-			require.NoError(t, mapErr)
-			require.Equal(t, tc.expect, cfgFromMapstructure)
+		t.Run(tc.Name, func(t *testing.T) {
+			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
 		})
 	}
-}
-
-func configFromFileViaYaml(file string) (*MoveOperatorConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	config := defaultCfg()
-	if err := yaml.Unmarshal(bytes, config); err != nil {
-		return nil, fmt.Errorf("failed to read config file as yaml: %s", err)
-	}
-
-	return config, nil
-}
-
-func configFromFileViaMapstructure(file string) (*MoveOperatorConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	raw := map[string]interface{}{}
-
-	if err := yaml.Unmarshal(bytes, raw); err != nil {
-		return nil, fmt.Errorf("failed to read data from yaml: %s", err)
-	}
-
-	cfg := defaultCfg()
-	dc := &mapstructure.DecoderConfig{Result: cfg, DecodeHook: helper.JSONUnmarshalerHook()}
-	ms, err := mapstructure.NewDecoder(dc)
-	if err != nil {
-		return nil, err
-	}
-	err = ms.Decode(raw)
-	if err != nil {
-		return nil, err
-	}
-	return cfg, nil
 }
 
 func defaultCfg() *MoveOperatorConfig {

--- a/operator/builtin/transformer/remove/config_test.go
+++ b/operator/builtin/transformer/remove/config_test.go
@@ -22,7 +22,7 @@ import (
 
 // test unmarshalling of values into config struct
 func TestGoldenConfig(t *testing.T) {
-	cases := []operatortest.ConfigTestCase{
+	cases := []operatortest.ConfigUnmarshalTest{
 		{
 			Name: "remove_body",
 			Expect: func() *RemoveOperatorConfig {
@@ -50,7 +50,7 @@ func TestGoldenConfig(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
+			tc.Run(t, defaultCfg())
 		})
 	}
 }

--- a/operator/builtin/transformer/remove/config_test.go
+++ b/operator/builtin/transformer/remove/config_test.go
@@ -14,46 +14,34 @@
 package remove
 
 import (
-	"fmt"
-	"io/ioutil"
-	"path"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
-
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
-	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper/operatortest"
 )
-
-type configTestCase struct {
-	name   string
-	expect *RemoveOperatorConfig
-}
 
 // test unmarshalling of values into config struct
 func TestGoldenConfig(t *testing.T) {
-	cases := []configTestCase{
+	cases := []operatortest.ConfigTestCase{
 		{
-			"remove_body",
-			func() *RemoveOperatorConfig {
+			Name: "remove_body",
+			Expect: func() *RemoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Field = entry.NewBodyField("nested")
 				return cfg
 			}(),
 		},
 		{
-			"remove_single_attribute",
-			func() *RemoveOperatorConfig {
+			Name: "remove_single_attribute",
+			Expect: func() *RemoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Field = entry.NewAttributeField("key")
 				return cfg
 			}(),
 		},
 		{
-			"remove_single_resource",
-			func() *RemoveOperatorConfig {
+			Name: "remove_single_resource",
+			Expect: func() *RemoveOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Field = entry.NewResourceField("key")
 				return cfg
@@ -61,54 +49,10 @@ func TestGoldenConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			cfgFromYaml, yamlErr := configFromFileViaYaml(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			cfgFromMapstructure, mapErr := configFromFileViaMapstructure(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			require.NoError(t, yamlErr)
-			require.Equal(t, tc.expect, cfgFromYaml)
-			require.NoError(t, mapErr)
-			require.Equal(t, tc.expect, cfgFromMapstructure)
+		t.Run(tc.Name, func(t *testing.T) {
+			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
 		})
 	}
-}
-
-func configFromFileViaYaml(file string) (*RemoveOperatorConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	config := defaultCfg()
-	if err := yaml.Unmarshal(bytes, config); err != nil {
-		return nil, fmt.Errorf("failed to read config file as yaml: %s", err)
-	}
-
-	return config, nil
-}
-
-func configFromFileViaMapstructure(file string) (*RemoveOperatorConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	raw := map[string]interface{}{}
-
-	if err := yaml.Unmarshal(bytes, raw); err != nil {
-		return nil, fmt.Errorf("failed to read data from yaml: %s", err)
-	}
-
-	cfg := defaultCfg()
-	dc := &mapstructure.DecoderConfig{Result: cfg, DecodeHook: helper.JSONUnmarshalerHook()}
-	ms, err := mapstructure.NewDecoder(dc)
-	if err != nil {
-		return nil, err
-	}
-	err = ms.Decode(raw)
-	if err != nil {
-		return nil, err
-	}
-	return cfg, nil
 }
 
 func defaultCfg() *RemoveOperatorConfig {

--- a/operator/builtin/transformer/retain/config_test.go
+++ b/operator/builtin/transformer/retain/config_test.go
@@ -22,7 +22,7 @@ import (
 
 // test unmarshalling of values into config struct
 func TestGoldenConfigs(t *testing.T) {
-	cases := []operatortest.ConfigTestCase{
+	cases := []operatortest.ConfigUnmarshalTest{
 		{
 			Name: "retain_single",
 			Expect: func() *RetainOperatorConfig {
@@ -87,7 +87,7 @@ func TestGoldenConfigs(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
+			tc.Run(t, defaultCfg())
 		})
 	}
 }

--- a/operator/builtin/transformer/retain/config_test.go
+++ b/operator/builtin/transformer/retain/config_test.go
@@ -14,38 +14,26 @@
 package retain
 
 import (
-	"fmt"
-	"io/ioutil"
-	"path"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
-
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
-	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper/operatortest"
 )
-
-type configTestCase struct {
-	name   string
-	expect *RetainOperatorConfig
-}
 
 // test unmarshalling of values into config struct
 func TestGoldenConfigs(t *testing.T) {
-	cases := []configTestCase{
+	cases := []operatortest.ConfigTestCase{
 		{
-			"retain_single",
-			func() *RetainOperatorConfig {
+			Name: "retain_single",
+			Expect: func() *RetainOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Fields = append(cfg.Fields, entry.NewBodyField("key"))
 				return cfg
 			}(),
 		},
 		{
-			"retain_multi",
-			func() *RetainOperatorConfig {
+			Name: "retain_multi",
+			Expect: func() *RetainOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Fields = append(cfg.Fields, entry.NewBodyField("key"))
 				cfg.Fields = append(cfg.Fields, entry.NewBodyField("nested2"))
@@ -53,16 +41,16 @@ func TestGoldenConfigs(t *testing.T) {
 			}(),
 		},
 		{
-			"retain_single_attribute",
-			func() *RetainOperatorConfig {
+			Name: "retain_single_attribute",
+			Expect: func() *RetainOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Fields = append(cfg.Fields, entry.NewAttributeField("key"))
 				return cfg
 			}(),
 		},
 		{
-			"retain_multi_attribute",
-			func() *RetainOperatorConfig {
+			Name: "retain_multi_attribute",
+			Expect: func() *RetainOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Fields = append(cfg.Fields, entry.NewAttributeField("key1"))
 				cfg.Fields = append(cfg.Fields, entry.NewAttributeField("key2"))
@@ -70,16 +58,16 @@ func TestGoldenConfigs(t *testing.T) {
 			}(),
 		},
 		{
-			"retain_single_resource",
-			func() *RetainOperatorConfig {
+			Name: "retain_single_resource",
+			Expect: func() *RetainOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Fields = append(cfg.Fields, entry.NewResourceField("key"))
 				return cfg
 			}(),
 		},
 		{
-			"retain_multi_resource",
-			func() *RetainOperatorConfig {
+			Name: "retain_multi_resource",
+			Expect: func() *RetainOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Fields = append(cfg.Fields, entry.NewResourceField("key1"))
 				cfg.Fields = append(cfg.Fields, entry.NewResourceField("key2"))
@@ -87,8 +75,8 @@ func TestGoldenConfigs(t *testing.T) {
 			}(),
 		},
 		{
-			"retain_one_of_each",
-			func() *RetainOperatorConfig {
+			Name: "retain_one_of_each",
+			Expect: func() *RetainOperatorConfig {
 				cfg := defaultCfg()
 				cfg.Fields = append(cfg.Fields, entry.NewResourceField("key1"))
 				cfg.Fields = append(cfg.Fields, entry.NewAttributeField("key3"))
@@ -98,54 +86,10 @@ func TestGoldenConfigs(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		t.Run("GoldenConfig/"+tc.name, func(t *testing.T) {
-			cfgFromYaml, yamlErr := configFromFileViaYaml(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			cfgFromMapstructure, mapErr := configFromFileViaMapstructure(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			require.NoError(t, yamlErr)
-			require.Equal(t, tc.expect, cfgFromYaml)
-			require.NoError(t, mapErr)
-			require.Equal(t, tc.expect, cfgFromMapstructure)
+		t.Run(tc.Name, func(t *testing.T) {
+			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
 		})
 	}
-}
-
-func configFromFileViaYaml(file string) (*RetainOperatorConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	config := defaultCfg()
-	if err := yaml.Unmarshal(bytes, config); err != nil {
-		return nil, fmt.Errorf("failed to read config file as yaml: %s", err)
-	}
-
-	return config, nil
-}
-
-func configFromFileViaMapstructure(file string) (*RetainOperatorConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	raw := map[string]interface{}{}
-
-	if err := yaml.Unmarshal(bytes, raw); err != nil {
-		return nil, fmt.Errorf("failed to read data from yaml: %s", err)
-	}
-
-	cfg := defaultCfg()
-	dc := &mapstructure.DecoderConfig{Result: cfg, DecodeHook: helper.JSONUnmarshalerHook()}
-	ms, err := mapstructure.NewDecoder(dc)
-	if err != nil {
-		return nil, err
-	}
-	err = ms.Decode(raw)
-	if err != nil {
-		return nil, err
-	}
-	return cfg, nil
 }
 
 func defaultCfg() *RetainOperatorConfig {

--- a/operator/builtin/transformer/router/config_test.go
+++ b/operator/builtin/transformer/router/config_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestRouterGoldenConfig(t *testing.T) {
-	cases := []operatortest.ConfigTestCase{
+	cases := []operatortest.ConfigUnmarshalTest{
 		{
 			Name:   "default",
 			Expect: defaultCfg(),
@@ -97,7 +97,7 @@ func TestRouterGoldenConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
+			tc.Run(t, defaultCfg())
 		})
 	}
 }

--- a/operator/builtin/transformer/router/config_test.go
+++ b/operator/builtin/transformer/router/config_test.go
@@ -14,34 +14,21 @@
 package router
 
 import (
-	"fmt"
-	"io/ioutil"
-	"path"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
-
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper/operatortest"
 )
 
-type testCase struct {
-	name      string
-	expectErr bool
-	expect    *RouterOperatorConfig
-}
-
 func TestRouterGoldenConfig(t *testing.T) {
-	cases := []testCase{
+	cases := []operatortest.ConfigTestCase{
 		{
-			"default",
-			false,
-			defaultCfg(),
+			Name:   "default",
+			Expect: defaultCfg(),
 		},
 		{
-			"routes_one",
-			false,
-			func() *RouterOperatorConfig {
+			Name: "routes_one",
+			Expect: func() *RouterOperatorConfig {
 				cfg := defaultCfg()
 				newRoute := &RouterOperatorRouteConfig{
 					Expression: `$.format == "json"`,
@@ -52,9 +39,8 @@ func TestRouterGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"routes_multi",
-			false,
-			func() *RouterOperatorConfig {
+			Name: "routes_multi",
+			Expect: func() *RouterOperatorConfig {
 				cfg := defaultCfg()
 				newRoute := []*RouterOperatorRouteConfig{
 					{
@@ -75,9 +61,8 @@ func TestRouterGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"routes_attributes",
-			false,
-			func() *RouterOperatorConfig {
+			Name: "routes_attributes",
+			Expect: func() *RouterOperatorConfig {
 				cfg := defaultCfg()
 
 				attVal := helper.NewAttributerConfig()
@@ -96,9 +81,8 @@ func TestRouterGoldenConfig(t *testing.T) {
 			}(),
 		},
 		{
-			"routes_default",
-			false,
-			func() *RouterOperatorConfig {
+			Name: "routes_default",
+			Expect: func() *RouterOperatorConfig {
 				cfg := defaultCfg()
 				newRoute := &RouterOperatorRouteConfig{
 					Expression: `$.format == "json"`,
@@ -112,59 +96,10 @@ func TestRouterGoldenConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run("yaml/"+tc.name, func(t *testing.T) {
-			cfgFromYaml, yamlErr := configFromFileViaYaml(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)))
-			if tc.expectErr {
-				require.Error(t, yamlErr)
-			} else {
-				require.NoError(t, yamlErr)
-				require.Equal(t, tc.expect, cfgFromYaml)
-			}
-		})
-		t.Run("mapstructure/"+tc.name, func(t *testing.T) {
-			cfgFromMapstructure := defaultCfg()
-			mapErr := configFromFileViaMapstructure(
-				path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.name)),
-				cfgFromMapstructure,
-			)
-			if tc.expectErr {
-				require.Error(t, mapErr)
-			} else {
-				require.NoError(t, mapErr)
-				require.Equal(t, tc.expect, cfgFromMapstructure)
-			}
+		t.Run(tc.Name, func(t *testing.T) {
+			operatortest.RunGoldenConfigTest(t, defaultCfg(), tc)
 		})
 	}
-}
-
-func configFromFileViaYaml(file string) (*RouterOperatorConfig, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("could not find config file: %s", err)
-	}
-
-	config := defaultCfg()
-	if err := yaml.Unmarshal(bytes, config); err != nil {
-		return nil, fmt.Errorf("failed to read config file as yaml: %s", err)
-	}
-
-	return config, nil
-}
-
-func configFromFileViaMapstructure(file string, result *RouterOperatorConfig) error {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return fmt.Errorf("could not find config file: %s", err)
-	}
-
-	raw := map[string]interface{}{}
-
-	if err := yaml.Unmarshal(bytes, raw); err != nil {
-		return fmt.Errorf("failed to read data from yaml: %s", err)
-	}
-
-	err = helper.UnmarshalMapstructure(raw, result)
-	return err
 }
 
 func defaultCfg() *RouterOperatorConfig {

--- a/operator/helper/operatortest/operatortest.go
+++ b/operator/helper/operatortest/operatortest.go
@@ -1,0 +1,46 @@
+package operatortest
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
+	"gopkg.in/yaml.v2"
+)
+
+func ConfigFromFileViaYaml(file string, config interface{}) (interface{}, error) {
+	bytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("could not find config file: %s", err)
+	}
+	if err := yaml.Unmarshal(bytes, config); err != nil {
+		return nil, fmt.Errorf("failed to read config file as yaml: %s", err)
+	}
+
+	return config, nil
+}
+
+func ConfigFromFileViaMapstructure(file string, config interface{}) (interface{}, error) {
+	bytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("could not find config file: %s", err)
+	}
+
+	raw := map[string]interface{}{}
+
+	if err := yaml.Unmarshal(bytes, raw); err != nil {
+		return nil, fmt.Errorf("failed to read data from yaml: %s", err)
+	}
+
+	dc := &mapstructure.DecoderConfig{Result: config, DecodeHook: helper.JSONUnmarshalerHook()}
+	ms, err := mapstructure.NewDecoder(dc)
+	if err != nil {
+		return nil, err
+	}
+	err = ms.Decode(raw)
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}

--- a/operator/helper/operatortest/operatortest.go
+++ b/operator/helper/operatortest/operatortest.go
@@ -27,7 +27,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
 )
 
-// ConfigTestCase is used for testing golden configs
+// ConfigUnmarshalTest is used for testing golden configs
 type ConfigUnmarshalTest struct {
 	Name      string
 	Expect    interface{}
@@ -70,7 +70,7 @@ func configFromFileViaMapstructure(file string, config interface{}) error {
 	return nil
 }
 
-// RunGoldenConfigTest Unmarshalls yaml files and compares them against the expected.
+// Run Unmarshalls yaml files and compares them against the expected.
 func (c ConfigUnmarshalTest) Run(t *testing.T, config interface{}) {
 	mapConfig := config
 	yamlConfig := config

--- a/operator/helper/operatortest/operatortest.go
+++ b/operator/helper/operatortest/operatortest.go
@@ -21,9 +21,10 @@ import (
 	"testing"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
 )
 
 // ConfigTestCase is used for testing golden configs

--- a/operator/helper/operatortest/operatortest.go
+++ b/operator/helper/operatortest/operatortest.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package operatortest
 
 import (
@@ -14,8 +28,9 @@ import (
 
 // ConfigTestCase is used for testing golden configs
 type ConfigTestCase struct {
-	Name   string
-	Expect interface{}
+	Name      string
+	Expect    interface{}
+	ExpectErr bool
 }
 
 func configFromFileViaYaml(file string, config interface{}) (interface{}, error) {
@@ -55,11 +70,17 @@ func configFromFileViaMapstructure(file string, config interface{}) (interface{}
 }
 
 // RunGoldenConfigTest Unmarshalls yaml files and compares them against the expected.
-func RunGoldenConfigTest(config interface{}, t *testing.T, tc ConfigTestCase) {
+func RunGoldenConfigTest(t *testing.T, config interface{}, tc ConfigTestCase) {
 	cfgFromYaml, yamlErr := configFromFileViaYaml(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.Name)), config)
 	cfgFromMapstructure, mapErr := configFromFileViaMapstructure(path.Join(".", "testdata", fmt.Sprintf("%s.yaml", tc.Name)), config)
-	require.NoError(t, yamlErr)
-	require.Equal(t, tc.Expect, cfgFromYaml)
-	require.NoError(t, mapErr)
-	require.Equal(t, tc.Expect, cfgFromMapstructure)
+
+	if tc.ExpectErr {
+		require.Error(t, mapErr)
+		require.Error(t, yamlErr)
+	} else {
+		require.NoError(t, yamlErr)
+		require.Equal(t, tc.Expect, cfgFromYaml)
+		require.NoError(t, mapErr)
+		require.Equal(t, tc.Expect, cfgFromMapstructure)
+	}
 }


### PR DESCRIPTION
This was done to reduce redundancy in golden config testing in the different operators.