### PR TITLE
Add basic net attributes to tcp/udp input

### DIFF
--- a/docs/operators/tcp_input.md
+++ b/docs/operators/tcp_input.md
@@ -4,16 +4,18 @@ The `tcp_input` operator listens for logs on one or more TCP connections. The op
 
 ### Configuration Fields
 
-| Field             | Default          | Description                                                                       |
-| ---               | ---              | ---                                                                               |
-| `id`              | `tcp_input`      | A unique identifier for the operator                                              |
-| `output`          | Next in pipeline | The connected operator(s) that will receive all outbound entries                  |
-| `max_buffer_size` | `1024kib`        | Maximum size of buffer that may be allocated while reading TCP input              |
-| `listen_address`  | required         | A listen address of the form `<ip>:<port>`                                        |
-| `tls`             | nil              | An optional `TLS` configuration (see the TLS configuration section)               |
-| `write_to`        | $                | The body [field](/docs/types/field.md) written to when creating a new log entry |
-| `attributes`      | {}               | A map of `key: value` pairs to add to the entry's attributes                         |
-| `resource`        | {}               | A map of `key: value` pairs to add to the entry's resource                       |
+| Field             | Default          | Description                                                                                        |
+| ---               | ---              | ---                                                                                                |
+| `id`              | `tcp_input`      | A unique identifier for the operator                                                               |
+| `output`          | Next in pipeline | The connected operator(s) that will receive all outbound entries                                   |
+| `max_buffer_size` | `1024kib`        | Maximum size of buffer that may be allocated while reading TCP input                               |
+| `listen_address`  | required         | A listen address of the form `<ip>:<port>`                                                         |
+| `tls`             | nil              | An optional `TLS` configuration (see the TLS configuration section)                                |
+| `write_to`        | $                | The body [field](/docs/types/field.md) written to when creating a new log entry                    |
+| `attributes`      | {}               | A map of `key: value` pairs to add to the entry's attributes                                       |
+| `resource`        | {}               | A map of `key: value` pairs to add to the entry's resource                                         |
+| `add_attributes`  | false            | Adds `net.transport`, `net.peer.ip`, `net.peer.port`, `net.host.ip` and `net.host.port` attributes |
+
 
 #### TLS Configuration
 

--- a/docs/operators/udp_input.md
+++ b/docs/operators/udp_input.md
@@ -4,14 +4,15 @@ The `udp_input` operator listens for logs from UDP packets.
 
 ### Configuration Fields
 
-| Field             | Default          | Description                                                                       |
-| ---               | ---              | ---                                                                               |
-| `id`              | `udp_input`      | A unique identifier for the operator                                              |
-| `output`          | Next in pipeline | The connected operator(s) that will receive all outbound entries                  |
-| `listen_address`  | required         | A listen address of the form `<ip>:<port>`                                        |
-| `write_to`        | $                | The body [field](/docs/types/field.md) written to when creating a new log entry |
-| `attributes`      | {}               | A map of `key: value` pairs to add to the entry's attributes                         |
-| `resource`        | {}               | A map of `key: value` pairs to add to the entry's resource                       |
+| Field             | Default          | Description                                                                                        |
+| ---               | ---              | ---                                                                                                |
+| `id`              | `udp_input`      | A unique identifier for the operator                                                               |
+| `output`          | Next in pipeline | The connected operator(s) that will receive all outbound entries                                   |
+| `listen_address`  | required         | A listen address of the form `<ip>:<port>`                                                         |
+| `write_to`        | $                | The body [field](/docs/types/field.md) written to when creating a new log entry                    |
+| `attributes`      | {}               | A map of `key: value` pairs to add to the entry's attributes                                       |
+| `resource`        | {}               | A map of `key: value` pairs to add to the entry's resource                                         |
+| `add_attributes`  | false            | Adds `net.transport`, `net.peer.ip`, `net.peer.port`, `net.host.ip` and `net.host.port` attributes |
 
 ### Example Configurations
 

--- a/operator/builtin/input/udp/udp_test.go
+++ b/operator/builtin/input/udp/udp_test.go
@@ -16,6 +16,7 @@ package udp
 
 import (
 	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -76,11 +77,82 @@ func udpInputTest(input []byte, expected []string) func(t *testing.T) {
 	}
 }
 
+func udpInputAttributesTest(input []byte, expected []string) func(t *testing.T) {
+	return func(t *testing.T) {
+		cfg := NewUDPInputConfig("test_input")
+		cfg.ListenAddress = ":0"
+		cfg.AddAttributes = true
+
+		ops, err := cfg.Build(testutil.NewBuildContext(t))
+		require.NoError(t, err)
+		op := ops[0]
+
+		mockOutput := testutil.Operator{}
+		udpInput, ok := op.(*UDPInput)
+		require.True(t, ok)
+
+		udpInput.InputOperator.OutputOperators = []operator.Operator{&mockOutput}
+
+		entryChan := make(chan *entry.Entry, 1)
+		mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			entryChan <- args.Get(1).(*entry.Entry)
+		}).Return(nil)
+
+		err = udpInput.Start(testutil.NewMockPersister("test"))
+		require.NoError(t, err)
+		defer udpInput.Stop()
+
+		conn, err := net.Dial("udp", udpInput.connection.LocalAddr().String())
+		require.NoError(t, err)
+		defer conn.Close()
+
+		_, err = conn.Write(input)
+		require.NoError(t, err)
+
+		for _, expectedBody := range expected {
+			select {
+			case entry := <-entryChan:
+				expectedAttributes := map[string]string{
+					"net.transport": "IP.UDP",
+				}
+				// LocalAddr for udpInput.connection is a server address
+				if addr, ok := udpInput.connection.LocalAddr().(*net.UDPAddr); ok {
+					expectedAttributes["net.host.ip"] = addr.IP.String()
+					expectedAttributes["net.host.port"] = strconv.FormatInt(int64(addr.Port), 10)
+				}
+				// LocalAddr for conn is a client (peer) address
+				if addr, ok := conn.LocalAddr().(*net.UDPAddr); ok {
+					expectedAttributes["net.peer.ip"] = addr.IP.String()
+					expectedAttributes["net.peer.port"] = strconv.FormatInt(int64(addr.Port), 10)
+				}
+				require.Equal(t, expectedBody, entry.Body)
+				require.Equal(t, expectedAttributes, entry.Attributes)
+			case <-time.After(time.Second):
+				require.FailNow(t, "Timed out waiting for message to be written")
+			}
+		}
+
+		select {
+		case entry := <-entryChan:
+			require.FailNow(t, "Unexpected entry: %s", entry)
+		case <-time.After(100 * time.Millisecond):
+			return
+		}
+	}
+}
+
 func TestUDPInput(t *testing.T) {
 	t.Run("Simple", udpInputTest([]byte("message1"), []string{"message1"}))
 	t.Run("TrailingNewlines", udpInputTest([]byte("message1\n"), []string{"message1"}))
 	t.Run("TrailingCRNewlines", udpInputTest([]byte("message1\r\n"), []string{"message1"}))
 	t.Run("NewlineInMessage", udpInputTest([]byte("message1\nmessage2\n"), []string{"message1\nmessage2"}))
+}
+
+func TestUDPInputAttributes(t *testing.T) {
+	t.Run("Simple", udpInputAttributesTest([]byte("message1"), []string{"message1"}))
+	t.Run("TrailingNewlines", udpInputAttributesTest([]byte("message1\n"), []string{"message1"}))
+	t.Run("TrailingCRNewlines", udpInputAttributesTest([]byte("message1\r\n"), []string{"message1"}))
+	t.Run("NewlineInMessage", udpInputAttributesTest([]byte("message1\nmessage2\n"), []string{"message1\nmessage2"}))
 }
 
 func BenchmarkUdpInput(b *testing.B) {


### PR DESCRIPTION
Adds listed attributes for tcp and udp operatos behind `add_attributes` configuration:
 - net.transport
 - net.peer.ip
 - net.peer.port
 - net.host.ip
 - net.host.port

[Semantic convention](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/host.md)

solves #106 