### PR TITLE
Resolve TCP Input panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- TCP Input Operator panic ([Issue](https://github.com/open-telemetry/opentelemetry-log-collection/issues/129))
+
 ## [0.17.0] - 2020-04-07
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/antonmedv/expr v1.8.9
 	github.com/bmatcuk/doublestar/v3 v3.0.0
+	github.com/jpillora/backoff v1.0.0
 	github.com/json-iterator/go v1.1.11
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/observiq/ctimefmt v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -542,6 +542,7 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=


### PR DESCRIPTION
After logging Accept's error, continue with the loop instead of running goHandleClose / goHandleMessage. A backoff is implemented to prevent the operator from logging too quickly. The first retry will handle 100ms later, progressively backing off to 3 seconds. This can be useful for situations where there is a "too many open files" error.

```
...
{"level":"debug","timestamp":"2021-05-06T19:33:31.286-0400","message":"Received connection: 10.33.104.10:41696","operator_id":"$.tcp_input_1","operator_type":"tcp_input"}
{"level":"debug","timestamp":"2021-05-06T19:33:31.296-0400","message":"Received connection: 10.33.104.10:41698","operator_id":"$.tcp_input_1","operator_type":"tcp_input"}
{"level":"debug","timestamp":"2021-05-06T19:33:31.305-0400","message":"Received connection: 10.33.104.10:41700","operator_id":"$.tcp_input_1","operator_type":"tcp_input"}
{"level":"debug","timestamp":"2021-05-06T19:33:31.305-0400","message":"Listener accept error","operator_id":"$.tcp_input_1","operator_type":"tcp_input","error":"accept tcp [::]:5000: accept4: too many open files"}
{"level":"debug","timestamp":"2021-05-06T19:33:31.406-0400","message":"Listener accept error","operator_id":"$.tcp_input_1","operator_type":"tcp_input","error":"accept tcp [::]:5000: accept4: too many open files"}
{"level":"debug","timestamp":"2021-05-06T19:33:31.606-0400","message":"Listener accept error","operator_id":"$.tcp_input_1","operator_type":"tcp_input","error":"accept tcp [::]:5000: accept4: too many open files"}
{"level":"debug","timestamp":"2021-05-06T19:33:32.008-0400","message":"Listener accept error","operator_id":"$.tcp_input_1","operator_type":"tcp_input","error":"accept tcp [::]:5000: accept4: too many open files"}
{"level":"debug","timestamp":"2021-05-06T19:33:32.809-0400","message":"Listener accept error","operator_id":"$.tcp_input_1","operator_type":"tcp_input","error":"accept tcp [::]:5000: accept4: too many open files"}
{"level":"debug","timestamp":"2021-05-06T19:33:34.409-0400","message":"Listener accept error","operator_id":"$.tcp_input_1","operator_type":"tcp_input","error":"accept tcp [::]:5000: accept4: too many open files"}
{"level":"debug","timestamp":"2021-05-06T19:33:37.410-0400","message":"Listener accept error","operator_id":"$.tcp_input_1","operator_type":"tcp_input","error":"accept tcp [::]:5000: accept4: too many open files"}
{"level":"debug","timestamp":"2021-05-06T19:33:40.410-0400","message":"Listener accept error","operator_id":"$.tcp_input_1","operator_type":"tcp_input","error":"accept tcp [::]:5000: accept4: too many open files"}
{"level":"debug","timestamp":"2021-05-06T19:33:43.410-0400","message":"Listener accept error","operator_id":"$.tcp_input_1","operator_type":"tcp_input","error":"accept tcp [::]:5000: accept4: too many open files"}
...
```

Resolves https://github.com/open-telemetry/opentelemetry-log-collection/issues/129