### PR TITLE
Add SetID func to operator Configs

### DIFF
--- a/operator/config.go
+++ b/operator/config.go
@@ -29,6 +29,7 @@ type Config struct {
 // Builder is an entity that can build a single operator
 type Builder interface {
 	ID() string
+	SetID(string) error
 	Type() string
 	Build(BuildContext) ([]Operator, error)
 }

--- a/operator/config_test.go
+++ b/operator/config_test.go
@@ -31,6 +31,7 @@ type FakeBuilder struct {
 func (f *FakeBuilder) Build(context BuildContext) ([]Operator, error) { return nil, nil }
 func (f *FakeBuilder) ID() string                                     { return "plugin" }
 func (f *FakeBuilder) Type() string                                   { return "plugin" }
+func (f *FakeBuilder) SetID(s string) error                           { return nil }
 
 func TestUnmarshalJSONErrors(t *testing.T) {
 	t.Cleanup(func() {

--- a/operator/helper/operator.go
+++ b/operator/helper/operator.go
@@ -43,6 +43,11 @@ func (c BasicConfig) ID() string {
 	return c.OperatorID
 }
 
+func (c BasicConfig) SetID(id string) error {
+	c.OperatorID = id
+	return nil
+}
+
 // Type will return the operator type.
 func (c BasicConfig) Type() string {
 	return c.OperatorType


### PR DESCRIPTION
This is to give the ability to modify the ids for autogeneration of ids when there are multiple ops with the same name.