### PR TITLE
Add missing network connection attributes to tcp/udp

### DIFF
--- a/docs/operators/tcp_input.md
+++ b/docs/operators/tcp_input.md
@@ -14,11 +14,9 @@ The `tcp_input` operator listens for logs on one or more TCP connections. The op
 | `write_to`        | $                | The body [field](/docs/types/field.md) written to when creating a new log entry                                    |
 | `attributes`      | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
 | `resource`        | {}               | A map of `key: value` pairs to add to the entry's resource                                                         |
-| `add_attributes`  | false            | Adds `net.*` attributes according to [semantic convention][1]                                                      |
+| `add_attributes`  | false            | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes] |
 | `multiline`       |                  | A `multiline` configuration block. See below for details                                                           |
 | `encoding`        | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options               |
-
-[1]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes
 
 #### TLS Configuration
 

--- a/docs/operators/tcp_input.md
+++ b/docs/operators/tcp_input.md
@@ -14,9 +14,11 @@ The `tcp_input` operator listens for logs on one or more TCP connections. The op
 | `write_to`        | $                | The body [field](/docs/types/field.md) written to when creating a new log entry                                    |
 | `attributes`      | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
 | `resource`        | {}               | A map of `key: value` pairs to add to the entry's resource                                                         |
-| `add_attributes`  | false            | Adds `net.transport`, `net.peer.ip`, `net.peer.port`, `net.host.ip` and `net.host.port` attributes                 |
+| `add_attributes`  | false            | Adds `net.*` attributes according to [semantic convention][1]                                                      |
 | `multiline`       |                  | A `multiline` configuration block. See below for details                                                           |
 | `encoding`        | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options               |
+
+[1]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes
 
 #### TLS Configuration
 

--- a/docs/operators/udp_input.md
+++ b/docs/operators/udp_input.md
@@ -12,9 +12,11 @@ The `udp_input` operator listens for logs from UDP packets.
 | `write_to`        | $                | The body [field](/docs/types/field.md) written to when creating a new log entry                                    |
 | `attributes`      | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
 | `resource`        | {}               | A map of `key: value` pairs to add to the entry's resource                                                         |
-| `add_attributes`  | false            | Adds `net.transport`, `net.peer.ip`, `net.peer.port`, `net.host.ip` and `net.host.port` attributes                 |
+| `add_attributes`  | false            | Adds `net.*` attributes according to [semantic convention][1]                                                      |
 | `multiline`       |                  | A `multiline` configuration block. See below for details                                                           |
 | `encoding`        | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options               |
+
+[1]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes
 
 #### `multiline` configuration
 

--- a/docs/operators/udp_input.md
+++ b/docs/operators/udp_input.md
@@ -12,11 +12,9 @@ The `udp_input` operator listens for logs from UDP packets.
 | `write_to`        | $                | The body [field](/docs/types/field.md) written to when creating a new log entry                                    |
 | `attributes`      | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
 | `resource`        | {}               | A map of `key: value` pairs to add to the entry's resource                                                         |
-| `add_attributes`  | false            | Adds `net.*` attributes according to [semantic convention][1]                                                      |
+| `add_attributes`  | false            | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes] |
 | `multiline`       |                  | A `multiline` configuration block. See below for details                                                           |
 | `encoding`        | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options               |
-
-[1]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes
 
 #### `multiline` configuration
 

--- a/operator/builtin/input/tcp/tcp.go
+++ b/operator/builtin/input/tcp/tcp.go
@@ -252,14 +252,14 @@ func (t *TCPInput) goHandleMessages(ctx context.Context, conn net.Conn, cancel c
 					ip := addr.IP.String()
 					entry.AddAttribute("net.peer.ip", ip)
 					entry.AddAttribute("net.peer.port", strconv.FormatInt(int64(addr.Port), 10))
-					entry.AddAttribute("net.peer.name", helper.LookupIpAddr(ip))
+					entry.AddAttribute("net.peer.name", helper.IPResolver.GetHostFromIp(ip))
 				}
 
 				if addr, ok := conn.LocalAddr().(*net.TCPAddr); ok {
 					ip := addr.IP.String()
 					entry.AddAttribute("net.host.ip", addr.IP.String())
 					entry.AddAttribute("net.host.port", strconv.FormatInt(int64(addr.Port), 10))
-					entry.AddAttribute("net.host.name", helper.LookupIpAddr(ip))
+					entry.AddAttribute("net.host.name", helper.IPResolver.GetHostFromIp(ip))
 				}
 			}
 
@@ -280,5 +280,6 @@ func (t *TCPInput) Stop() error {
 	}
 
 	t.wg.Wait()
+	helper.IPResolver.Stop()
 	return nil
 }

--- a/operator/builtin/input/tcp/tcp.go
+++ b/operator/builtin/input/tcp/tcp.go
@@ -249,13 +249,17 @@ func (t *TCPInput) goHandleMessages(ctx context.Context, conn net.Conn, cancel c
 			if t.addAttributes {
 				entry.AddAttribute("net.transport", "IP.TCP")
 				if addr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
-					entry.AddAttribute("net.peer.ip", addr.IP.String())
+					ip := addr.IP.String()
+					entry.AddAttribute("net.peer.ip", ip)
 					entry.AddAttribute("net.peer.port", strconv.FormatInt(int64(addr.Port), 10))
+					entry.AddAttribute("net.peer.name", helper.LookupIpAddr(ip))
 				}
 
 				if addr, ok := conn.LocalAddr().(*net.TCPAddr); ok {
+					ip := addr.IP.String()
 					entry.AddAttribute("net.host.ip", addr.IP.String())
 					entry.AddAttribute("net.host.port", strconv.FormatInt(int64(addr.Port), 10))
+					entry.AddAttribute("net.host.name", helper.LookupIpAddr(ip))
 				}
 			}
 

--- a/operator/builtin/input/tcp/tcp.go
+++ b/operator/builtin/input/tcp/tcp.go
@@ -103,6 +103,11 @@ func (c TCPInputConfig) Build(context operator.BuildContext) ([]operator.Operato
 		return nil, err
 	}
 
+	var resolver *helper.IPResolver = nil
+	if c.AddAttributes {
+		resolver = helper.NewIpResolver()
+	}
+
 	tcpInput := &TCPInput{
 		InputOperator: inputOperator,
 		address:       c.ListenAddress,
@@ -113,7 +118,7 @@ func (c TCPInputConfig) Build(context operator.BuildContext) ([]operator.Operato
 		backoff: backoff.Backoff{
 			Max: 3 * time.Second,
 		},
-		resolver: helper.NewIpResolver(),
+		resolver: resolver,
 	}
 
 	if c.TLS != nil {
@@ -282,6 +287,8 @@ func (t *TCPInput) Stop() error {
 	}
 
 	t.wg.Wait()
-	t.resolver.Stop()
+	if t.resolver != nil {
+		t.resolver.Stop()
+	}
 	return nil
 }

--- a/operator/builtin/input/tcp/tcp_test.go
+++ b/operator/builtin/input/tcp/tcp_test.go
@@ -171,13 +171,13 @@ func tcpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 					ip := addr.IP.String()
 					expectedAttributes["net.host.ip"] = addr.IP.String()
 					expectedAttributes["net.host.port"] = strconv.FormatInt(int64(addr.Port), 10)
-					expectedAttributes["net.host.name"] = helper.IPResolver.GetHostFromIp(ip)
+					expectedAttributes["net.host.name"] = tcpInput.resolver.GetHostFromIp(ip)
 				}
 				if addr, ok := conn.LocalAddr().(*net.TCPAddr); ok {
 					ip := addr.IP.String()
 					expectedAttributes["net.peer.ip"] = ip
 					expectedAttributes["net.peer.port"] = strconv.FormatInt(int64(addr.Port), 10)
-					expectedAttributes["net.peer.name"] = helper.IPResolver.GetHostFromIp(ip)
+					expectedAttributes["net.peer.name"] = tcpInput.resolver.GetHostFromIp(ip)
 				}
 				require.Equal(t, expectedMessage, entry.Body)
 				require.Equal(t, expectedAttributes, entry.Attributes)

--- a/operator/builtin/input/tcp/tcp_test.go
+++ b/operator/builtin/input/tcp/tcp_test.go
@@ -168,12 +168,16 @@ func tcpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 					"net.transport": "IP.TCP",
 				}
 				if addr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+					ip := addr.IP.String()
 					expectedAttributes["net.host.ip"] = addr.IP.String()
 					expectedAttributes["net.host.port"] = strconv.FormatInt(int64(addr.Port), 10)
+					expectedAttributes["net.host.name"] = helper.LookupIpAddr(ip)
 				}
 				if addr, ok := conn.LocalAddr().(*net.TCPAddr); ok {
-					expectedAttributes["net.peer.ip"] = addr.IP.String()
+					ip := addr.IP.String()
+					expectedAttributes["net.peer.ip"] = ip
 					expectedAttributes["net.peer.port"] = strconv.FormatInt(int64(addr.Port), 10)
+					expectedAttributes["net.peer.name"] = helper.LookupIpAddr(ip)
 				}
 				require.Equal(t, expectedMessage, entry.Body)
 				require.Equal(t, expectedAttributes, entry.Attributes)

--- a/operator/builtin/input/tcp/tcp_test.go
+++ b/operator/builtin/input/tcp/tcp_test.go
@@ -171,13 +171,13 @@ func tcpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 					ip := addr.IP.String()
 					expectedAttributes["net.host.ip"] = addr.IP.String()
 					expectedAttributes["net.host.port"] = strconv.FormatInt(int64(addr.Port), 10)
-					expectedAttributes["net.host.name"] = helper.LookupIpAddr(ip)
+					expectedAttributes["net.host.name"] = helper.IPResolver.GetHostFromIp(ip)
 				}
 				if addr, ok := conn.LocalAddr().(*net.TCPAddr); ok {
 					ip := addr.IP.String()
 					expectedAttributes["net.peer.ip"] = ip
 					expectedAttributes["net.peer.port"] = strconv.FormatInt(int64(addr.Port), 10)
-					expectedAttributes["net.peer.name"] = helper.LookupIpAddr(ip)
+					expectedAttributes["net.peer.name"] = helper.IPResolver.GetHostFromIp(ip)
 				}
 				require.Equal(t, expectedMessage, entry.Body)
 				require.Equal(t, expectedAttributes, entry.Attributes)

--- a/operator/builtin/input/udp/udp.go
+++ b/operator/builtin/input/udp/udp.go
@@ -168,13 +168,17 @@ func (u *UDPInput) goHandleMessages(ctx context.Context) {
 				if u.addAttributes {
 					entry.AddAttribute("net.transport", "IP.UDP")
 					if addr, ok := u.connection.LocalAddr().(*net.UDPAddr); ok {
+						ip := addr.IP.String()
 						entry.AddAttribute("net.host.ip", addr.IP.String())
 						entry.AddAttribute("net.host.port", strconv.FormatInt(int64(addr.Port), 10))
+						entry.AddAttribute("net.host.name", helper.LookupIpAddr(ip))
 					}
 
 					if addr, ok := remoteAddr.(*net.UDPAddr); ok {
-						entry.AddAttribute("net.peer.ip", addr.IP.String())
+						ip := addr.IP.String()
+						entry.AddAttribute("net.peer.ip", ip)
 						entry.AddAttribute("net.peer.port", strconv.FormatInt(int64(addr.Port), 10))
+						entry.AddAttribute("net.peer.name", helper.LookupIpAddr(ip))
 					}
 				}
 

--- a/operator/builtin/input/udp/udp.go
+++ b/operator/builtin/input/udp/udp.go
@@ -86,6 +86,11 @@ func (c UDPInputConfig) Build(context operator.BuildContext) ([]operator.Operato
 		return nil, err
 	}
 
+	var resolver *helper.IPResolver = nil
+	if c.AddAttributes {
+		resolver = helper.NewIpResolver()
+	}
+
 	udpInput := &UDPInput{
 		InputOperator: inputOperator,
 		address:       address,
@@ -93,7 +98,7 @@ func (c UDPInputConfig) Build(context operator.BuildContext) ([]operator.Operato
 		addAttributes: c.AddAttributes,
 		encoding:      encoding,
 		splitFunc:     splitFunc,
-		resolver:      helper.NewIpResolver(),
+		resolver:      resolver,
 	}
 	return []operator.Operator{udpInput}, nil
 }
@@ -212,6 +217,8 @@ func (u *UDPInput) Stop() error {
 	u.cancel()
 	u.connection.Close()
 	u.wg.Wait()
-	u.resolver.Stop()
+	if u.resolver != nil {
+		u.resolver.Stop()
+	}
 	return nil
 }

--- a/operator/builtin/input/udp/udp.go
+++ b/operator/builtin/input/udp/udp.go
@@ -171,14 +171,14 @@ func (u *UDPInput) goHandleMessages(ctx context.Context) {
 						ip := addr.IP.String()
 						entry.AddAttribute("net.host.ip", addr.IP.String())
 						entry.AddAttribute("net.host.port", strconv.FormatInt(int64(addr.Port), 10))
-						entry.AddAttribute("net.host.name", helper.LookupIpAddr(ip))
+						entry.AddAttribute("net.host.name", helper.IPResolver.GetHostFromIp(ip))
 					}
 
 					if addr, ok := remoteAddr.(*net.UDPAddr); ok {
 						ip := addr.IP.String()
 						entry.AddAttribute("net.peer.ip", ip)
 						entry.AddAttribute("net.peer.port", strconv.FormatInt(int64(addr.Port), 10))
-						entry.AddAttribute("net.peer.name", helper.LookupIpAddr(ip))
+						entry.AddAttribute("net.peer.name", helper.IPResolver.GetHostFromIp(ip))
 					}
 				}
 
@@ -210,5 +210,6 @@ func (u *UDPInput) Stop() error {
 	u.cancel()
 	u.connection.Close()
 	u.wg.Wait()
+	helper.IPResolver.Stop()
 	return nil
 }

--- a/operator/builtin/input/udp/udp_test.go
+++ b/operator/builtin/input/udp/udp_test.go
@@ -121,14 +121,14 @@ func udpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 					ip := addr.IP.String()
 					expectedAttributes["net.host.ip"] = addr.IP.String()
 					expectedAttributes["net.host.port"] = strconv.FormatInt(int64(addr.Port), 10)
-					expectedAttributes["net.host.name"] = helper.LookupIpAddr(ip)
+					expectedAttributes["net.host.name"] = helper.IPResolver.GetHostFromIp(ip)
 				}
 				// LocalAddr for conn is a client (peer) address
 				if addr, ok := conn.LocalAddr().(*net.UDPAddr); ok {
 					ip := addr.IP.String()
 					expectedAttributes["net.peer.ip"] = ip
 					expectedAttributes["net.peer.port"] = strconv.FormatInt(int64(addr.Port), 10)
-					expectedAttributes["net.peer.name"] = helper.LookupIpAddr(ip)
+					expectedAttributes["net.peer.name"] = helper.IPResolver.GetHostFromIp(ip)
 				}
 				require.Equal(t, expectedBody, entry.Body)
 				require.Equal(t, expectedAttributes, entry.Attributes)

--- a/operator/builtin/input/udp/udp_test.go
+++ b/operator/builtin/input/udp/udp_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
 	"github.com/open-telemetry/opentelemetry-log-collection/testutil"
 )
 
@@ -117,13 +118,17 @@ func udpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 				}
 				// LocalAddr for udpInput.connection is a server address
 				if addr, ok := udpInput.connection.LocalAddr().(*net.UDPAddr); ok {
+					ip := addr.IP.String()
 					expectedAttributes["net.host.ip"] = addr.IP.String()
 					expectedAttributes["net.host.port"] = strconv.FormatInt(int64(addr.Port), 10)
+					expectedAttributes["net.host.name"] = helper.LookupIpAddr(ip)
 				}
 				// LocalAddr for conn is a client (peer) address
 				if addr, ok := conn.LocalAddr().(*net.UDPAddr); ok {
-					expectedAttributes["net.peer.ip"] = addr.IP.String()
+					ip := addr.IP.String()
+					expectedAttributes["net.peer.ip"] = ip
 					expectedAttributes["net.peer.port"] = strconv.FormatInt(int64(addr.Port), 10)
+					expectedAttributes["net.peer.name"] = helper.LookupIpAddr(ip)
 				}
 				require.Equal(t, expectedBody, entry.Body)
 				require.Equal(t, expectedAttributes, entry.Attributes)

--- a/operator/builtin/input/udp/udp_test.go
+++ b/operator/builtin/input/udp/udp_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator"
-	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
 	"github.com/open-telemetry/opentelemetry-log-collection/testutil"
 )
 
@@ -121,14 +120,14 @@ func udpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 					ip := addr.IP.String()
 					expectedAttributes["net.host.ip"] = addr.IP.String()
 					expectedAttributes["net.host.port"] = strconv.FormatInt(int64(addr.Port), 10)
-					expectedAttributes["net.host.name"] = helper.IPResolver.GetHostFromIp(ip)
+					expectedAttributes["net.host.name"] = udpInput.resolver.GetHostFromIp(ip)
 				}
 				// LocalAddr for conn is a client (peer) address
 				if addr, ok := conn.LocalAddr().(*net.UDPAddr); ok {
 					ip := addr.IP.String()
 					expectedAttributes["net.peer.ip"] = ip
 					expectedAttributes["net.peer.port"] = strconv.FormatInt(int64(addr.Port), 10)
-					expectedAttributes["net.peer.name"] = helper.IPResolver.GetHostFromIp(ip)
+					expectedAttributes["net.peer.name"] = udpInput.resolver.GetHostFromIp(ip)
 				}
 				require.Equal(t, expectedBody, entry.Body)
 				require.Equal(t, expectedAttributes, entry.Attributes)

--- a/operator/helper/ip_resolver.go
+++ b/operator/helper/ip_resolver.go
@@ -73,17 +73,22 @@ func (r *IPResolver) start() {
 				ticker.Stop()
 				return
 			case <-ticker.C:
-				now := time.Now()
 				r.mutex.Lock()
-				for key, entry := range r.cache {
-					if entry.expireTime.Before(now) {
-						delete(r.cache, key)
-					}
-				}
+				r.invalidateCache()
 				r.mutex.Unlock()
 			}
 		}
 	}()
+}
+
+// invalidateCache removes not longer valid entries from cache
+func (r *IPResolver) invalidateCache() {
+	now := time.Now()
+	for key, entry := range r.cache {
+		if entry.expireTime.Before(now) {
+			delete(r.cache, key)
+		}
+	}
 }
 
 // GetHostFromIp returns hostname for given ip

--- a/operator/helper/ip_resolver.go
+++ b/operator/helper/ip_resolver.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import "net"
+
+func LookupIpAddr(ip string) (host string) {
+	res, err := net.LookupAddr(ip)
+	if err != nil || len(res) == 0 {
+		return ip
+	}
+
+	host = res[0]
+	// Trim one trailing '.'.
+	if last := len(host) - 1; last >= 0 && host[last] == '.' {
+		host = host[:last]
+	}
+	return host
+}

--- a/operator/helper/ip_resolver.go
+++ b/operator/helper/ip_resolver.go
@@ -65,7 +65,7 @@ func (r *IPResolver) Stop() {
 
 // start runs cache invalidation every 5 minutes
 func (r *IPResolver) start() {
-	ticker := time.NewTicker(5 * time.Minute)
+	ticker := time.NewTicker(r.invalidationInterval)
 	go func() {
 		for {
 			select {

--- a/operator/helper/ip_resolver_test.go
+++ b/operator/helper/ip_resolver_test.go
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIPResolverCacheLookup(t *testing.T) {
+	resolver := NewIpResolver()
+	resolver.cache["127.0.0.1"] = cacheEntry{
+		hostname:   "definitely invalid hostname",
+		expireTime: time.Now().Add(time.Hour),
+	}
+
+	require.Equal(t, "definitely invalid hostname", resolver.GetHostFromIp("127.0.0.1"))
+}
+
+func TestIPResolverCacheInvalidation(t *testing.T) {
+	resolver := NewIpResolver()
+
+	resolver.Stop()
+	resolver.invalidationInterval = time.Millisecond
+	resolver.start()
+
+	time.Sleep(2 * time.Second)
+
+	resolver.cache["127.0.0.1"] = cacheEntry{
+		hostname:   "definitely invalid hostname",
+		expireTime: time.Now().Add(-1 * time.Hour),
+	}
+
+	hostname := resolver.lookupIpAddr("127.0.0.1")
+
+	require.Equal(t, hostname, resolver.GetHostFromIp("127.0.0.1"))
+}
+
+func TestIPResolver100Hits(t *testing.T) {
+	resolver := NewIpResolver()
+	resolver.cache["127.0.0.1"] = cacheEntry{
+		hostname:   "definitely invalid hostname",
+		expireTime: time.Now().Add(time.Hour),
+	}
+
+	for i := 0; i < 100; i++ {
+		require.Equal(t, "definitely invalid hostname", resolver.GetHostFromIp("127.0.0.1"))
+	}
+}
+
+func TestIPResolverWithMultipleStops(t *testing.T) {
+	resolver := NewIpResolver()
+
+	resolver.Stop()
+	resolver.Stop()
+}

--- a/operator/helper/ip_resolver_test.go
+++ b/operator/helper/ip_resolver_test.go
@@ -15,8 +15,10 @@
 package helper
 
 import (
+	"fmt"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 )
@@ -34,19 +36,15 @@ func TestIPResolverCacheLookup(t *testing.T) {
 func TestIPResolverCacheInvalidation(t *testing.T) {
 	resolver := NewIpResolver()
 
-	resolver.Stop()
-	resolver.invalidationInterval = time.Millisecond
-	resolver.start()
-
-	time.Sleep(2 * time.Second)
-
 	resolver.cache["127.0.0.1"] = cacheEntry{
 		hostname:   "definitely invalid hostname",
 		expireTime: time.Now().Add(-1 * time.Hour),
 	}
 
-	hostname := resolver.lookupIpAddr("127.0.0.1")
+	resolver.Stop()
+	resolver.invalidateCache()
 
+	hostname := resolver.lookupIpAddr("127.0.0.1")
 	require.Equal(t, hostname, resolver.GetHostFromIp("127.0.0.1"))
 }
 
@@ -67,4 +65,11 @@ func TestIPResolverWithMultipleStops(t *testing.T) {
 
 	resolver.Stop()
 	resolver.Stop()
+}
+
+func TestSizes(t *testing.T) {
+	fmt.Printf("string %v \n", unsafe.Sizeof(""))
+	fmt.Printf("cache entry %v \n", unsafe.Sizeof(cacheEntry{}))
+	fmt.Printf("time %v \n", unsafe.Sizeof(time.Now()))
+	fmt.Printf("time %v \n", unsafe.Sizeof(time.Now()))
 }


### PR DESCRIPTION
Add missing network connection attributes (`net.peer.name` and `net.host.name`) according to [semantic convension](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes)