### PR TITLE
failing test for files rotated outside of Include path parameter

### DIFF
--- a/operator/builtin/input/file/file_test.go
+++ b/operator/builtin/input/file/file_test.go
@@ -879,6 +879,38 @@ func TestMoveFile(t *testing.T) {
 	expectNoMessages(t, logReceived)
 }
 
+func TestTrackMovedAwayFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Moving files while open is unsupported on Windows")
+	}
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	operator.persister = testutil.NewMockPersister("test")
+
+	temp1 := openTemp(t, tempDir)
+	writeString(t, temp1, "testlog1\n")
+	temp1.Close()
+
+	operator.poll(context.Background())
+	defer operator.Stop()
+
+	waitForMessage(t, logReceived, "testlog1")
+
+	// Wait until all goroutines are finished before renaming
+	operator.wg.Wait()
+	tempDir2 := os.TempDir()
+	newFileName := fmt.Sprintf("%s%s", tempDir2, "newfile.log")
+	err := os.Rename(temp1.Name(), newFileName)
+	require.NoError(t, err)
+
+	movedFile, err := os.OpenFile(newFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	require.NoError(t, err)
+	writeString(t, movedFile, "testlog2\n")
+	operator.poll(context.Background())
+
+	waitForMessage(t, logReceived, "testlog2")
+}
+
 // TruncateThenWrite tests that, after a file has been truncated,
 // any new writes are picked up
 func TestTruncateThenWrite(t *testing.T) {

--- a/operator/builtin/input/file/file_test.go
+++ b/operator/builtin/input/file/file_test.go
@@ -879,6 +879,7 @@ func TestMoveFile(t *testing.T) {
 	expectNoMessages(t, logReceived)
 }
 
+
 func TestTrackMovedAwayFiles(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Moving files while open is unsupported on Windows")
@@ -898,9 +899,13 @@ func TestTrackMovedAwayFiles(t *testing.T) {
 
 	// Wait until all goroutines are finished before renaming
 	operator.wg.Wait()
-	tempDir2 := os.TempDir()
-	newFileName := fmt.Sprintf("%s%s", tempDir2, "newfile.log")
-	err := os.Rename(temp1.Name(), newFileName)
+
+	newDir := fmt.Sprintf("%s%s", tempDir[:len(tempDir)-1], "_new/")
+	err := os.Mkdir(newDir, 0777)
+	require.NoError(t, err)
+	newFileName := fmt.Sprintf("%s%s", newDir, "newfile.log")
+
+	err = os.Rename(temp1.Name(), newFileName)
 	require.NoError(t, err)
 
 	movedFile, err := os.OpenFile(newFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)


### PR DESCRIPTION
#140 fixes this failing test
When tailing file get rotated to a path that it is no longer matched by `Include` path parameter, it loses trace of it. 
this is issue with kubernetes container logs because it has to tail symlinks file created by `kubelet` to parse out other metadata from file path itself. 