### PR TITLE
Remove byte handling from parsers

### DIFF
--- a/operator/builtin/parser/csv/csv.go
+++ b/operator/builtin/parser/csv/csv.go
@@ -100,8 +100,6 @@ func (r *CSVParser) parse(value interface{}) (interface{}, error) {
 	switch val := value.(type) {
 	case string:
 		csvLine = val
-	case []byte:
-		csvLine = string(val)
 	default:
 		return nil, fmt.Errorf("type '%T' cannot be parsed as csv", value)
 	}

--- a/operator/builtin/parser/csv/csv_test.go
+++ b/operator/builtin/parser/csv/csv_test.go
@@ -54,6 +54,13 @@ func TestCSVParserBuildFailureInvalidDelimiter(t *testing.T) {
 	require.Contains(t, err.Error(), "Invalid 'delimiter': ';;'")
 }
 
+func TestCSVParserByteFailure(t *testing.T) {
+	parser := newTestParser(t)
+	_, err := parser.parse([]byte("invalid"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "type '[]uint8' cannot be parsed as csv")
+}
+
 func TestCSVParserStringFailure(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse("invalid")

--- a/operator/builtin/parser/csv/csv_test.go
+++ b/operator/builtin/parser/csv/csv_test.go
@@ -61,13 +61,6 @@ func TestCSVParserStringFailure(t *testing.T) {
 	require.Contains(t, err.Error(), "record on line 1: wrong number of fields")
 }
 
-func TestCSVParserByteFailure(t *testing.T) {
-	parser := newTestParser(t)
-	_, err := parser.parse([]byte("invalid"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "record on line 1: wrong number of fields")
-}
-
 func TestCSVParserInvalidType(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse([]int{})

--- a/operator/builtin/parser/json/json.go
+++ b/operator/builtin/parser/json/json.go
@@ -76,11 +76,6 @@ func (j *JSONParser) parse(value interface{}) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-	case []byte:
-		err := j.json.Unmarshal(m, &parsedValue)
-		if err != nil {
-			return nil, err
-		}
 	default:
 		return nil, fmt.Errorf("type %T cannot be parsed as JSON", value)
 	}

--- a/operator/builtin/parser/json/json_test.go
+++ b/operator/builtin/parser/json/json_test.go
@@ -62,13 +62,6 @@ func TestJSONParserStringFailure(t *testing.T) {
 	require.Contains(t, err.Error(), "error found in #1 byte")
 }
 
-func TestJSONParserByteFailure(t *testing.T) {
-	parser := newTestParser(t)
-	_, err := parser.parse([]byte("invalid"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "error found in #1 byte")
-}
-
 func TestJSONParserInvalidType(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse([]int{})

--- a/operator/builtin/parser/json/json_test.go
+++ b/operator/builtin/parser/json/json_test.go
@@ -62,6 +62,13 @@ func TestJSONParserStringFailure(t *testing.T) {
 	require.Contains(t, err.Error(), "error found in #1 byte")
 }
 
+func TestJSONParserByteFailure(t *testing.T) {
+	parser := newTestParser(t)
+	_, err := parser.parse([]byte("invalid"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "type []uint8 cannot be parsed as JSON")
+}
+
 func TestJSONParserInvalidType(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse([]int{})

--- a/operator/builtin/parser/regex/regex.go
+++ b/operator/builtin/parser/regex/regex.go
@@ -100,16 +100,6 @@ func (r *RegexParser) parse(value interface{}) (interface{}, error) {
 		if matches == nil {
 			return nil, fmt.Errorf("regex pattern does not match")
 		}
-	case []byte:
-		byteMatches := r.regexp.FindSubmatch(m)
-		if byteMatches == nil {
-			return nil, fmt.Errorf("regex pattern does not match")
-		}
-
-		matches = make([]string, len(byteMatches))
-		for i, byteSlice := range byteMatches {
-			matches[i] = string(byteSlice)
-		}
 	default:
 		return nil, fmt.Errorf("type '%T' cannot be parsed as regex", value)
 	}

--- a/operator/builtin/parser/regex/regex_test.go
+++ b/operator/builtin/parser/regex/regex_test.go
@@ -44,6 +44,13 @@ func TestRegexParserBuildFailure(t *testing.T) {
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
 
+func TestRegexParserByteFailure(t *testing.T) {
+	parser := newTestParser(t, "^(?P<key>test)")
+	_, err := parser.parse([]byte("invalid"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "type '[]uint8' cannot be parsed as regex")
+}
+
 func TestRegexParserStringFailure(t *testing.T) {
 	parser := newTestParser(t, "^(?P<key>test)")
 	_, err := parser.parse("invalid")

--- a/operator/builtin/parser/regex/regex_test.go
+++ b/operator/builtin/parser/regex/regex_test.go
@@ -51,13 +51,6 @@ func TestRegexParserStringFailure(t *testing.T) {
 	require.Contains(t, err.Error(), "regex pattern does not match")
 }
 
-func TestRegexParserByteFailure(t *testing.T) {
-	parser := newTestParser(t, "^(?P<key>test)")
-	_, err := parser.parse([]byte("invalid"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "regex pattern does not match")
-}
-
 func TestRegexParserInvalidType(t *testing.T) {
 	parser := newTestParser(t, "^(?P<key>test)")
 	_, err := parser.parse([]int{})
@@ -78,16 +71,6 @@ func TestParserRegex(t *testing.T) {
 				p.Regex = "a=(?P<a>.*)"
 			},
 			"a=b",
-			map[string]interface{}{
-				"a": "b",
-			},
-		},
-		{
-			"RootBytes",
-			func(p *RegexParserConfig) {
-				p.Regex = "a=(?P<a>.*)"
-			},
-			[]byte("a=b"),
 			map[string]interface{}{
 				"a": "b",
 			},

--- a/operator/builtin/parser/syslog/data.go
+++ b/operator/builtin/parser/syslog/data.go
@@ -115,25 +115,6 @@ func CreateCases(basicConfig func() *SyslogParserConfig) ([]Case, error) {
 			"crit",
 		},
 		{
-			"RFC3164Bytes",
-			func() *SyslogParserConfig {
-				cfg := basicConfig()
-				cfg.Protocol = RFC3164
-				return cfg
-			}(),
-			[]byte("<34>Jan 12 06:30:00 1.2.3.4 apache_server: test message"),
-			time.Date(time.Now().Year(), 1, 12, 6, 30, 0, 0, time.UTC),
-			map[string]interface{}{
-				"appname":  "apache_server",
-				"facility": 4,
-				"hostname": "1.2.3.4",
-				"message":  "test message",
-				"priority": 34,
-			},
-			entry.Critical,
-			"crit",
-		},
-		{
 			"RFC5424",
 			func() *SyslogParserConfig {
 				cfg := basicConfig()

--- a/operator/builtin/parser/syslog/syslog.go
+++ b/operator/builtin/parser/syslog/syslog.go
@@ -213,8 +213,6 @@ func toBytes(value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case string:
 		return []byte(v), nil
-	case []byte:
-		return v, nil
 	default:
 		return nil, fmt.Errorf("unable to convert type '%T' to bytes", value)
 	}

--- a/operator/builtin/parser/uri/uri.go
+++ b/operator/builtin/parser/uri/uri.go
@@ -70,8 +70,6 @@ func (u *URIParser) parse(value interface{}) (interface{}, error) {
 	switch m := value.(type) {
 	case string:
 		return parseURI(m)
-	case []byte:
-		return parseURI(string(m))
 	default:
 		return nil, fmt.Errorf("type '%T' cannot be parsed as URI", value)
 	}

--- a/operator/builtin/parser/uri/uri_test.go
+++ b/operator/builtin/parser/uri/uri_test.go
@@ -49,13 +49,6 @@ func TestURIParserStringFailure(t *testing.T) {
 	require.Contains(t, err.Error(), "parse \"invalid\": invalid URI for request")
 }
 
-func TestURIParserByteFailure(t *testing.T) {
-	parser := newTestParser(t)
-	_, err := parser.parse([]byte("invalid"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "parse \"invalid\": invalid URI for request")
-}
-
 func TestRegexParserInvalidType(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse([]int{})
@@ -84,27 +77,6 @@ func TestURIParserParse(t *testing.T) {
 				},
 			},
 			false,
-		},
-		{
-			"byte",
-			[]byte("http://google.com/app?env=prod"),
-			map[string]interface{}{
-				"scheme": "http",
-				"host":   "google.com",
-				"path":   "/app",
-				"query": map[string]interface{}{
-					"env": []interface{}{
-						"prod",
-					},
-				},
-			},
-			false,
-		},
-		{
-			"byte",
-			[]int{},
-			map[string]interface{}{},
-			true,
 		},
 	}
 

--- a/operator/builtin/parser/uri/uri_test.go
+++ b/operator/builtin/parser/uri/uri_test.go
@@ -42,6 +42,13 @@ func TestURIParserBuildFailure(t *testing.T) {
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
 
+func TestURIParserByteFailure(t *testing.T) {
+	parser := newTestParser(t)
+	_, err := parser.parse([]byte("invalid"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "type '[]uint8' cannot be parsed as URI")
+}
+
 func TestURIParserStringFailure(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse("invalid")


### PR DESCRIPTION
Remove byte handling for `csv_parser`, `json_parser`, `regex_parser`, `syslog_parser`, and `uri_parser`. Resolves https://github.com/open-telemetry/opentelemetry-log-collection/issues/135