### PR TITLE
Add CodeQL Security Scans

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,34 @@
+name: "CodeQL Analysis"
+on:
+  workflow_dispatch:
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        *  * * * *
+    - cron: '30 1 * * *'
+
+jobs:
+  CodeQL-Build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: go
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,9 @@ on:
     #        *  * * * *
     - cron: '30 1 * * *'
 
+  pull_request:
+    branches: [ main ]
+
 jobs:
   CodeQL-Build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `add`, `remove`, `move`, `copy`, `retain`, and `flatten` operators, as alternatives to the `restructure` operator. 
 - `add_attributes` option to `tcp_input` and `udp_input`, for capturing network attributes ([PR108](https://github.com/open-telemetry/opentelemetry-log-collection/pull/108))
 - `multiline`, `encoding`, and `max_log_size` options to `tcp_input` ([PR125](https://github.com/open-telemetry/opentelemetry-log-collection/pull/125))
+- CodeQL workflow added to GitHub Actions [PR###]()
 
 ### Removed
 - Database package. The same functionality is supported via a `Persister` interface, passed to `Start` methods ([PR93](https://github.com/open-telemetry/opentelemetry-log-collection/pull/93))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `add`, `remove`, `move`, `copy`, `retain`, and `flatten` operators, as alternatives to the `restructure` operator. 
 - `add_attributes` option to `tcp_input` and `udp_input`, for capturing network attributes ([PR108](https://github.com/open-telemetry/opentelemetry-log-collection/pull/108))
 - `multiline`, `encoding`, and `max_log_size` options to `tcp_input` ([PR125](https://github.com/open-telemetry/opentelemetry-log-collection/pull/125))
-- CodeQL workflow added to GitHub Actions [PR###]()
+- CodeQL workflow added to GitHub Actions ([PR153](https://github.com/open-telemetry/opentelemetry-log-collection/pull/153))
 
 ### Removed
 - Database package. The same functionality is supported via a `Persister` interface, passed to `Start` methods ([PR93](https://github.com/open-telemetry/opentelemetry-log-collection/pull/93))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `add`, `remove`, `move`, `copy`, `retain`, and `flatten` operators, as alternatives to the `restructure` operator. 
 - `add_attributes` option to `tcp_input` and `udp_input`, for capturing network attributes ([PR108](https://github.com/open-telemetry/opentelemetry-log-collection/pull/108))
 - `multiline`, `encoding`, and `max_log_size` options to `tcp_input` ([PR125](https://github.com/open-telemetry/opentelemetry-log-collection/pull/125))
+## Unreleased
+
+### Added
 - CodeQL workflow added to GitHub Actions ([PR153](https://github.com/open-telemetry/opentelemetry-log-collection/pull/153))
 
 ### Removed


### PR DESCRIPTION
## Motivation
Follow up to issue Follow up to issue open-telemetry/oteps#144

[CodeQL](https://github.com/github/codeql) is GitHub's static analysis engine which scans repos for security vulnerabilities. As the project grows and we near GA it might be useful to have a workflow which checks for security vulnerabilities with every PR so we can ensure every incremental change is following best development practices. Also passing basic security checks will also make sure that there aren't any glaring issues for our users.

## Changes
This PR adds CodeQL security checks to the repo
* After every run the workflow uploads the results to GitHub. Details on the run and security alerts will show up in the security tab of this repo.

**Workflow Triggers**
* daily cron job at 1:30am
* workflow_dispatch (in case maintainers want to trigger a security check manually)

cc- @alolita