### PR TITLE
udp: Do not init buffer for every packet

### DIFF
--- a/operator/builtin/input/udp/udp.go
+++ b/operator/builtin/input/udp/udp.go
@@ -141,6 +141,7 @@ func (u *UDPInput) goHandleMessages(ctx context.Context) {
 	go func() {
 		defer u.wg.Done()
 
+		buf := make([]byte, 0, MaxUDPSize)
 		for {
 			message, remoteAddr, err := u.readMessage()
 			if err != nil {
@@ -153,7 +154,6 @@ func (u *UDPInput) goHandleMessages(ctx context.Context) {
 				break
 			}
 
-			buf := make([]byte, 0, MaxUDPSize)
 			scanner := bufio.NewScanner(bytes.NewReader(message))
 			scanner.Buffer(buf, MaxUDPSize)
 


### PR DESCRIPTION
As buffer is used across one thread there is no need to reinitialize it for every packet