### PR TITLE
Fix codecov configuration

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -11,8 +11,12 @@ coverage:
   status:
     project:
       default:
-        target: 50%
+        target: auto
         threshold: 0.5%
+    patch:
+      default:
+        target: 50%
+        threshold: 0%
 
 comment:
   layout: "reach,diff,flags,tree"


### PR DESCRIPTION
Intention is that project coverage should always increase. In order to accomplish this, patch coverage must be 50% or greater.