### PR TITLE
Run benchmarks on pull request

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-${{ hashFiles('**/go.mod') }}
-      - name: Run Unit Tests
+      - name: Run Benchmarks
         run: make bench
 
   bench-macos:
@@ -123,7 +123,7 @@ jobs:
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-${{ hashFiles('**/go.mod') }}
-      - name: Run Unit Tests
+      - name: Run Benchmarks
         run: make bench
         
   bench-windows:
@@ -142,5 +142,5 @@ jobs:
         with:
           path: /Users/runneradmin/go/pkg/mod
           key: ${{ runner.os }}-${{ hashFiles('**/go.mod') }}
-      - name: Run Unit Tests
+      - name: Run Benchmarks
         run: make bench

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,3 +88,59 @@ jobs:
       - name: Run Unit Tests
         run: make test
           
+  bench-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: Cache Go Modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-modules
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-${{ hashFiles('**/go.mod') }}
+      - name: Run Unit Tests
+        run: make bench
+
+  bench-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: Cache Go Modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-modules
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-${{ hashFiles('**/go.mod') }}
+      - name: Run Unit Tests
+        run: make bench
+        
+  bench-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: 1.15
+      - name: Cache Go Modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-modules
+        with:
+          path: /Users/runneradmin/go/pkg/mod
+          key: ${{ runner.os }}-${{ hashFiles('**/go.mod') }}
+      - name: Run Unit Tests
+        run: make bench


### PR DESCRIPTION
File input benchmarks caught a potential issue on #168. 

Ideally, the issue will be reproduced in a unit test. However, running benchmarks is the quickest way to validate the change.