### PR TITLE
Track rotated

### DIFF
--- a/docs/operators/file_input.md
+++ b/docs/operators/file_input.md
@@ -19,7 +19,7 @@ The `file_input` operator reads logs from files. It will place the lines read in
 | `start_at`             | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
 | `fingerprint_size`     | `1kb`            | The number of bytes with which to identify a file. The first bytes in the file are used as the fingerprint. Decreasing this value at any point will cause existing fingerprints to forgotten, meaning that all files will be read from the beginning (one time). |
 | `max_log_size`         | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |
-| `max_concurrent_files` | 1024             | The maximum number of log files from which logs will be read concurrently. If the number of files matched in the `include` pattern exceeds this number, then files will be processed in batches. One batch will be processed per `poll_interval`. |
+| `max_concurrent_files` | 1024             | The maximum number of log files from which logs will be read concurrently (minimum = 2). If the number of files matched in the `include` pattern exceeds half of this number, then files will be processed in batches. One batch will be processed per `poll_interval`. |
 | `attributes`           | {}               | A map of `key: value` pairs to add to the entry's attributes                                                          |
 | `resource`             | {}               | A map of `key: value` pairs to add to the entry's resource                                                        |
 
@@ -37,6 +37,11 @@ match either the beginning of a new log entry, or the end of a log entry.
 
 Also refer to [recombine](/docs/operators/recombine.md) operator for merging events with greater control. 
  
+### File rotation
+
+When files are rotated and its new names are no longer captured in `include` pattern (i.e. tailing symlink files), it could result in data loss.
+To avoid the data loss, choose move/create rotation method and set `max_concurrent_files` higher than the twice of the number of files to tail. 
+
 ### Supported encodings
 
 | Key        | Description

--- a/operator/builtin/input/file/benchmark_test.go
+++ b/operator/builtin/input/file/benchmark_test.go
@@ -104,7 +104,7 @@ func BenchmarkFileInput(b *testing.B) {
 				cfg.Include = []string{
 					"file*.log",
 				}
-				cfg.MaxConcurrentFiles = 1
+				cfg.MaxConcurrentFiles = 2
 				return cfg
 			},
 		},

--- a/operator/builtin/input/file/config.go
+++ b/operator/builtin/input/file/config.go
@@ -98,8 +98,8 @@ func (c InputConfig) Build(context operator.BuildContext) ([]operator.Operator, 
 		return nil, fmt.Errorf("`max_log_size` must be positive")
 	}
 
-	if c.MaxConcurrentFiles <= 0 {
-		return nil, fmt.Errorf("`max_concurrent_files` must be positive")
+	if c.MaxConcurrentFiles <= 1 {
+		return nil, fmt.Errorf("`max_concurrent_files` must be greater than 1")
 	}
 
 	if c.FingerprintSize == 0 {

--- a/operator/builtin/input/file/reader.go
+++ b/operator/builtin/input/file/reader.go
@@ -84,12 +84,6 @@ func (f *Reader) InitializeOffset(startAtBeginning bool) error {
 
 // ReadToEnd will read until the end of the file
 func (f *Reader) ReadToEnd(ctx context.Context) {
-	defer func() {
-		if err := f.file.Close(); err != nil {
-			f.Errorw("Failed to close", zap.Error(err))
-		}
-	}()
-
 	if _, err := f.file.Seek(f.Offset, 0); err != nil {
 		f.Errorw("Failed to seek", zap.Error(err))
 		return
@@ -122,8 +116,12 @@ func (f *Reader) ReadToEnd(ctx context.Context) {
 }
 
 // Close will close the file
-func (f *Reader) Close() error {
-	return f.file.Close()
+func (f *Reader) Close() {
+	if f.file != nil {
+		if err := f.file.Close(); err != nil {
+			f.Debugf("Problem closing reader", "Error", err.Error())
+		}
+	}
 }
 
 // Emit creates an entry with the decoded message and sends it to the next

--- a/operator/builtin/input/file/rotation_test.go
+++ b/operator/builtin/input/file/rotation_test.go
@@ -32,7 +32,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-log-collection/testutil"
 )
 
+const WINDOWS_OS = "windows"
+
 func TestMultiFileRotate(t *testing.T) {
+	if runtime.GOOS == WINDOWS_OS {
+		// Windows has very poor support for moving active files, so rotation is less commonly used
+		// This may possibly be handled better in Go 1.16: https://github.com/golang/go/issues/35358
+		t.Skip()
+	}
 	t.Parallel()
 
 	getMessage := func(f, k, m int) string { return fmt.Sprintf("file %d-%d, message %d", f, k, m) }
@@ -82,7 +89,7 @@ func TestMultiFileRotate(t *testing.T) {
 }
 
 func TestMultiFileRotateSlow(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == WINDOWS_OS {
 		// Windows has very poor support for moving active files, so rotation is less commonly used
 		// This may possibly be handled better in Go 1.16: https://github.com/golang/go/issues/35358
 		t.Skip()
@@ -322,15 +329,19 @@ func TestRotation(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(fmt.Sprintf("%s/MoveCreateTimestamped", tc.name), tc.run(tc, false, false))
-		t.Run(fmt.Sprintf("%s/MoveCreateSequential", tc.name), tc.run(tc, false, true))
+		if runtime.GOOS != WINDOWS_OS {
+			// Windows has very poor support for moving active files, so rotation is less commonly used
+			// This may possibly be handled better in Go 1.16: https://github.com/golang/go/issues/35358
+			t.Run(fmt.Sprintf("%s/MoveCreateTimestamped", tc.name), tc.run(tc, false, false))
+			t.Run(fmt.Sprintf("%s/MoveCreateSequential", tc.name), tc.run(tc, false, true))
+		}
 		t.Run(fmt.Sprintf("%s/CopyTruncateTimestamped", tc.name), tc.run(tc, true, false))
 		t.Run(fmt.Sprintf("%s/CopyTruncateSequential", tc.name), tc.run(tc, true, true))
 	}
 }
 
 func TestMoveFile(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == WINDOWS_OS {
 		t.Skip("Moving files while open is unsupported on Windows")
 	}
 	t.Parallel()
@@ -353,6 +364,42 @@ func TestMoveFile(t *testing.T) {
 
 	operator.poll(context.Background())
 	expectNoMessages(t, logReceived)
+}
+
+func TestTrackMovedAwayFiles(t *testing.T) {
+	if runtime.GOOS == WINDOWS_OS {
+		t.Skip("Moving files while open is unsupported on Windows")
+	}
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	operator.persister = testutil.NewMockPersister("test")
+
+	temp1 := openTemp(t, tempDir)
+	writeString(t, temp1, "testlog1\n")
+	temp1.Close()
+
+	operator.poll(context.Background())
+	defer operator.Stop()
+
+	waitForMessage(t, logReceived, "testlog1")
+
+	// Wait until all goroutines are finished before renaming
+	operator.wg.Wait()
+
+	newDir := fmt.Sprintf("%s%s", tempDir[:len(tempDir)-1], "_new/")
+	err := os.Mkdir(newDir, 0777)
+	require.NoError(t, err)
+	newFileName := fmt.Sprintf("%s%s", newDir, "newfile.log")
+
+	err = os.Rename(temp1.Name(), newFileName)
+	require.NoError(t, err)
+
+	movedFile, err := os.OpenFile(newFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	require.NoError(t, err)
+	writeString(t, movedFile, "testlog2\n")
+	operator.poll(context.Background())
+
+	waitForMessage(t, logReceived, "testlog2")
 }
 
 // TruncateThenWrite tests that, after a file has been truncated,

--- a/operator/builtin/input/file/util_test.go
+++ b/operator/builtin/input/file/util_test.go
@@ -35,7 +35,7 @@ import (
 
 func newDefaultConfig(tempDir string) *InputConfig {
 	cfg := NewInputConfig("testfile")
-	cfg.PollInterval = helper.Duration{Duration: 50 * time.Millisecond}
+	cfg.PollInterval = helper.Duration{Duration: 200 * time.Millisecond}
 	cfg.StartAt = "beginning"
 	cfg.Include = []string{fmt.Sprintf("%s/*", tempDir)}
 	cfg.OutputIDs = []string{"fake"}
@@ -122,7 +122,7 @@ func waitForOne(t *testing.T, c chan *entry.Entry) *entry.Entry {
 	select {
 	case e := <-c:
 		return e
-	case <-time.After(time.Second):
+	case <-time.After(3 * time.Second):
 		require.FailNow(t, "Timed out waiting for message")
 		return nil
 	}
@@ -134,7 +134,7 @@ func waitForN(t *testing.T, c chan *entry.Entry, n int) []string {
 		select {
 		case e := <-c:
 			messages = append(messages, e.Body.(string))
-		case <-time.After(time.Second):
+		case <-time.After(3 * time.Second):
 			require.FailNow(t, "Timed out waiting for message")
 			return nil
 		}
@@ -146,7 +146,7 @@ func waitForMessage(t *testing.T, c chan *entry.Entry, expected string) {
 	select {
 	case e := <-c:
 		require.Equal(t, expected, e.Body.(string))
-	case <-time.After(time.Second):
+	case <-time.After(3 * time.Second):
 		require.FailNow(t, "Timed out waiting for message", expected)
 	}
 }
@@ -158,7 +158,7 @@ LOOP:
 		select {
 		case e := <-c:
 			receivedMessages = append(receivedMessages, e.Body.(string))
-		case <-time.After(time.Second):
+		case <-time.After(3 * time.Second):
 			break LOOP
 		}
 	}


### PR DESCRIPTION
continuing #168
fixes #85 

instead of closing all files at the end of `poll` cycle, keep them open till next poll cycle. Only after opening all matched files, consume files that kept open from previous poll and close. By having this "overlap" at each cycle, we make sure we have trace of moved away files and consume any logs that were written to it but not yet read before being rotated. 

In addition, there were "Move/Create" rotation tests not being skipped for windows. I skipped those. 

