### PR TITLE
filelog: add file_name_resolved and file_path_resolved attributes

### DIFF
--- a/docs/operators/file_input.md
+++ b/docs/operators/file_input.md
@@ -4,24 +4,26 @@ The `file_input` operator reads logs from files. It will place the lines read in
 
 ### Configuration Fields
 
-| Field                  | Default          | Description                                                                                                        |
-| ---                    | ---              | ---                                                                                                                |
-| `id`                   | `file_input`     | A unique identifier for the operator                                                                               |
-| `output`               | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                   |
-| `include`              | required         | A list of file glob patterns that match the file paths to be read                                                  |
-| `exclude`              | []               | A list of file glob patterns to exclude from reading                                                               |
-| `poll_interval`        | 200ms            | The duration between filesystem polls                                                                              |
-| `multiline`            |                  | A `multiline` configuration block. See below for details                                                           |
-| `write_to`             | `$body`          | The body [field](/docs/types/field.md) written to when creating a new log entry                                  |
-| `encoding`             | `utf-8`            | The encoding of the file being read. See the list of supported encodings below for available options               |
-| `include_file_name`    | `true`           | Whether to add the file name as the attribute `file_name`                                                              |
-| `include_file_path`    | `false`          | Whether to add the file path as the label `file_path`                                                              |
-| `start_at`             | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
-| `fingerprint_size`     | `1kb`            | The number of bytes with which to identify a file. The first bytes in the file are used as the fingerprint. Decreasing this value at any point will cause existing fingerprints to forgotten, meaning that all files will be read from the beginning (one time). |
-| `max_log_size`         | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |
-| `max_concurrent_files` | 1024             | The maximum number of log files from which logs will be read concurrently. If the number of files matched in the `include` pattern exceeds this number, then files will be processed in batches. One batch will be processed per `poll_interval`. |
-| `attributes`           | {}               | A map of `key: value` pairs to add to the entry's attributes                                                          |
-| `resource`             | {}               | A map of `key: value` pairs to add to the entry's resource                                                        |
+| Field                           | Default          | Description                                                                                                        |
+| ---                             | ---              | ---                                                                                                                |
+| `id`                            | `file_input`     | A unique identifier for the operator                                                                               |
+| `output`                        | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                   |
+| `include`                       | required         | A list of file glob patterns that match the file paths to be read                                                  |
+| `exclude`                       | []               | A list of file glob patterns to exclude from reading                                                               |
+| `poll_interval`                 | 200ms            | The duration between filesystem polls                                                                              |
+| `multiline`                     |                  | A `multiline` configuration block. See below for details                                                           |
+| `write_to`                      | `$body`          | The body [field](/docs/types/field.md) written to when creating a new log entry                                    |
+| `encoding`                      | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options               |
+| `include_file_name`             | `true`           | Whether to add the file name as the attribute `file_name`                                                          |
+| `include_file_path`             | `false`          | Whether to add the file path as the attribute `file_path`                                                          |
+| `include_file_name_resolved`    | `false`          | Whether to add the file name after symlinks resolution as the attribute `file_name_resolved`                       |
+| `include_file_path_resolved`    | `false`          | Whether to add the file path after symlinks resolution as the attribute `file_path_resolved`                       |
+| `start_at`                      | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
+| `fingerprint_size`              | `1kb`            | The number of bytes with which to identify a file. The first bytes in the file are used as the fingerprint. Decreasing this value at any point will cause existing fingerprints to forgotten, meaning that all files will be read from the beginning (one time). |
+| `max_log_size`                  | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |
+| `max_concurrent_files`          | 1024             | The maximum number of log files from which logs will be read concurrently. If the number of files matched in the `include` pattern exceeds this number, then files will be processed in batches. One batch will be processed per `poll_interval`. |
+| `attributes`                    | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
+| `resource`                      | {}               | A map of `key: value` pairs to add to the entry's resource                                                         |
 
 Note that by default, no logs will be read unless the monitored file is actively being written to because `start_at` defaults to `end`.
 

--- a/operator/builtin/input/file/config.go
+++ b/operator/builtin/input/file/config.go
@@ -37,15 +37,17 @@ const (
 // NewInputConfig creates a new input config with default values
 func NewInputConfig(operatorID string) *InputConfig {
 	return &InputConfig{
-		InputConfig:        helper.NewInputConfig(operatorID, "file_input"),
-		PollInterval:       helper.Duration{Duration: 200 * time.Millisecond},
-		IncludeFileName:    true,
-		IncludeFilePath:    false,
-		StartAt:            "end",
-		FingerprintSize:    defaultFingerprintSize,
-		MaxLogSize:         defaultMaxLogSize,
-		MaxConcurrentFiles: defaultMaxConcurrentFiles,
-		Encoding:           helper.NewEncodingConfig(),
+		InputConfig:             helper.NewInputConfig(operatorID, "file_input"),
+		PollInterval:            helper.Duration{Duration: 200 * time.Millisecond},
+		IncludeFileName:         true,
+		IncludeFilePath:         false,
+		IncludeFileNameResolved: false,
+		IncludeFilePathResolved: false,
+		StartAt:                 "end",
+		FingerprintSize:         defaultFingerprintSize,
+		MaxLogSize:              defaultMaxLogSize,
+		MaxConcurrentFiles:      defaultMaxConcurrentFiles,
+		Encoding:                helper.NewEncodingConfig(),
 	}
 }
 
@@ -56,15 +58,17 @@ type InputConfig struct {
 	Include []string `mapstructure:"include,omitempty" json:"include,omitempty" yaml:"include,omitempty"`
 	Exclude []string `mapstructure:"exclude,omitempty" json:"exclude,omitempty" yaml:"exclude,omitempty"`
 
-	PollInterval       helper.Duration        `mapstructure:"poll_interval,omitempty"         json:"poll_interval,omitempty"        yaml:"poll_interval,omitempty"`
-	Multiline          helper.MultilineConfig `mapstructure:"multiline,omitempty"             json:"multiline,omitempty"            yaml:"multiline,omitempty"`
-	IncludeFileName    bool                   `mapstructure:"include_file_name,omitempty"     json:"include_file_name,omitempty"    yaml:"include_file_name,omitempty"`
-	IncludeFilePath    bool                   `mapstructure:"include_file_path,omitempty"     json:"include_file_path,omitempty"    yaml:"include_file_path,omitempty"`
-	StartAt            string                 `mapstructure:"start_at,omitempty"              json:"start_at,omitempty"             yaml:"start_at,omitempty"`
-	FingerprintSize    helper.ByteSize        `mapstructure:"fingerprint_size,omitempty"      json:"fingerprint_size,omitempty"     yaml:"fingerprint_size,omitempty"`
-	MaxLogSize         helper.ByteSize        `mapstructure:"max_log_size,omitempty"          json:"max_log_size,omitempty"         yaml:"max_log_size,omitempty"`
-	MaxConcurrentFiles int                    `mapstructure:"max_concurrent_files,omitempty"  json:"max_concurrent_files,omitempty" yaml:"max_concurrent_files,omitempty"`
-	Encoding           helper.EncodingConfig  `mapstructure:",squash,omitempty"               json:",inline,omitempty"              yaml:",inline,omitempty"`
+	PollInterval            helper.Duration        `mapstructure:"poll_interval,omitempty"                  json:"poll_interval,omitempty"                 yaml:"poll_interval,omitempty"`
+	Multiline               helper.MultilineConfig `mapstructure:"multiline,omitempty"                      json:"multiline,omitempty"                     yaml:"multiline,omitempty"`
+	IncludeFileName         bool                   `mapstructure:"include_file_name,omitempty"              json:"include_file_name,omitempty"             yaml:"include_file_name,omitempty"`
+	IncludeFilePath         bool                   `mapstructure:"include_file_path,omitempty"              json:"include_file_path,omitempty"             yaml:"include_file_path,omitempty"`
+	IncludeFileNameResolved bool                   `mapstructure:"include_file_name_resolved,omitempty"     json:"include_file_name_resolved,omitempty"    yaml:"include_file_name_resolved,omitempty"`
+	IncludeFilePathResolved bool                   `mapstructure:"include_file_path_resolved,omitempty"     json:"include_file_path_resolved,omitempty"    yaml:"include_file_path_resolved,omitempty"`
+	StartAt                 string                 `mapstructure:"start_at,omitempty"                       json:"start_at,omitempty"                      yaml:"start_at,omitempty"`
+	FingerprintSize         helper.ByteSize        `mapstructure:"fingerprint_size,omitempty"               json:"fingerprint_size,omitempty"              yaml:"fingerprint_size,omitempty"`
+	MaxLogSize              helper.ByteSize        `mapstructure:"max_log_size,omitempty"                   json:"max_log_size,omitempty"                  yaml:"max_log_size,omitempty"`
+	MaxConcurrentFiles      int                    `mapstructure:"max_concurrent_files,omitempty"           json:"max_concurrent_files,omitempty"          yaml:"max_concurrent_files,omitempty"`
+	Encoding                helper.EncodingConfig  `mapstructure:",squash,omitempty"                        json:",inline,omitempty"                       yaml:",inline,omitempty"`
 }
 
 // Build will build a file input operator from the supplied configuration
@@ -138,24 +142,36 @@ func (c InputConfig) Build(context operator.BuildContext) ([]operator.Operator, 
 		filePathField = entry.NewAttributeField("file_path")
 	}
 
+	fileNameResolvedField := entry.NewNilField()
+	if c.IncludeFileNameResolved {
+		fileNameResolvedField = entry.NewAttributeField("file_name_resolved")
+	}
+
+	filePathResolvedField := entry.NewNilField()
+	if c.IncludeFilePathResolved {
+		filePathResolvedField = entry.NewAttributeField("file_path_resolved")
+	}
+
 	op := &InputOperator{
-		InputOperator:      inputOperator,
-		Include:            c.Include,
-		Exclude:            c.Exclude,
-		SplitFunc:          splitFunc,
-		PollInterval:       c.PollInterval.Raw(),
-		FilePathField:      filePathField,
-		FileNameField:      fileNameField,
-		startAtBeginning:   startAtBeginning,
-		queuedMatches:      make([]string, 0),
-		encoding:           encoding,
-		firstCheck:         true,
-		cancel:             func() {},
-		knownFiles:         make([]*Reader, 0, 10),
-		fingerprintSize:    int(c.FingerprintSize),
-		MaxLogSize:         int(c.MaxLogSize),
-		MaxConcurrentFiles: c.MaxConcurrentFiles,
-		SeenPaths:          make(map[string]struct{}, 100),
+		InputOperator:         inputOperator,
+		Include:               c.Include,
+		Exclude:               c.Exclude,
+		SplitFunc:             splitFunc,
+		PollInterval:          c.PollInterval.Raw(),
+		FilePathField:         filePathField,
+		FileNameField:         fileNameField,
+		FilePathResolvedField: filePathResolvedField,
+		FileNameResolvedField: fileNameResolvedField,
+		startAtBeginning:      startAtBeginning,
+		queuedMatches:         make([]string, 0),
+		encoding:              encoding,
+		firstCheck:            true,
+		cancel:                func() {},
+		knownFiles:            make([]*Reader, 0, 10),
+		fingerprintSize:       int(c.FingerprintSize),
+		MaxLogSize:            int(c.MaxLogSize),
+		MaxConcurrentFiles:    c.MaxConcurrentFiles,
+		SeenPaths:             make(map[string]struct{}, 100),
 	}
 
 	return []operator.Operator{op}, nil

--- a/operator/builtin/input/file/file.go
+++ b/operator/builtin/input/file/file.go
@@ -37,15 +37,17 @@ import (
 type InputOperator struct {
 	helper.InputOperator
 
-	Include            []string
-	Exclude            []string
-	FilePathField      entry.Field
-	FileNameField      entry.Field
-	PollInterval       time.Duration
-	SplitFunc          bufio.SplitFunc
-	MaxLogSize         int
-	MaxConcurrentFiles int
-	SeenPaths          map[string]struct{}
+	Include               []string
+	Exclude               []string
+	FilePathField         entry.Field
+	FileNameField         entry.Field
+	FilePathResolvedField entry.Field
+	FileNameResolvedField entry.Field
+	PollInterval          time.Duration
+	SplitFunc             bufio.SplitFunc
+	MaxLogSize            int
+	MaxConcurrentFiles    int
+	SeenPaths             map[string]struct{}
 
 	persister operator.Persister
 

--- a/operator/builtin/input/file/file.go
+++ b/operator/builtin/input/file/file.go
@@ -289,7 +289,7 @@ func (f *InputOperator) newReader(file *os.File, fp *Fingerprint, firstCheck boo
 		if err != nil {
 			return nil, err
 		}
-		newReader.Path = file.Name()
+		newReader.SetPath(file.Name())
 		return newReader, nil
 	}
 

--- a/operator/builtin/input/file/file_test.go
+++ b/operator/builtin/input/file/file_test.go
@@ -112,6 +112,82 @@ func TestAddFileResolvedFields(t *testing.T) {
 	os.RemoveAll(dir)
 }
 
+// AddFileResolvedFields tests that the `file_name_resolved` and `file_path_resolved` fields are included
+// when IncludeFileNameResolved and IncludeFilePathResolved are set to true and underlaying symlink change
+// Scenario:
+// monitored file (symlink) -> middleSymlink -> file_1
+// monitored file (symlink) -> middleSymlink -> file_2
+func TestAddFileResolvedFieldsWithChangeOfSymlinkTarget(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *InputConfig) {
+		cfg.IncludeFileName = true
+		cfg.IncludeFilePath = true
+		cfg.IncludeFileNameResolved = true
+		cfg.IncludeFilePathResolved = true
+	}, nil)
+
+	// Create temp dir with log file
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+
+	file1, err := ioutil.TempFile(dir, "")
+	require.NoError(t, err)
+
+	file2, err := ioutil.TempFile(dir, "")
+	require.NoError(t, err)
+
+	// Resolve paths
+	real1, err := filepath.EvalSymlinks(file1.Name())
+	require.NoError(t, err)
+	resolved1, err := filepath.Abs(real1)
+	require.NoError(t, err)
+
+	real2, err := filepath.EvalSymlinks(file2.Name())
+	require.NoError(t, err)
+	resolved2, err := filepath.Abs(real2)
+	require.NoError(t, err)
+
+	// Create symbolic link in monitored directory
+	// symLinkPath(target of file input) -> middleSymLinkPath -> file1
+	middleSymLinkPath := filepath.Join(dir, "symlink")
+	symLinkPath := filepath.Join(tempDir, "symlink")
+	err = os.Symlink(file1.Name(), middleSymLinkPath)
+	require.NoError(t, err)
+	err = os.Symlink(middleSymLinkPath, symLinkPath)
+	require.NoError(t, err)
+
+	// Populate data
+	writeString(t, file1, "testlog\n")
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer operator.Stop()
+
+	e := waitForOne(t, logReceived)
+	require.Equal(t, filepath.Base(symLinkPath), e.Attributes["file_name"])
+	require.Equal(t, symLinkPath, e.Attributes["file_path"])
+	require.Equal(t, filepath.Base(resolved1), e.Attributes["file_name_resolved"])
+	require.Equal(t, resolved1, e.Attributes["file_path_resolved"])
+
+	// Change middleSymLink to point to file2
+	err = os.Remove(middleSymLinkPath)
+	require.NoError(t, err)
+	err = os.Symlink(file2.Name(), middleSymLinkPath)
+	require.NoError(t, err)
+
+	// Populate data (different content due to fingerprint)
+	writeString(t, file2, "testlog2\n")
+
+	e = waitForOne(t, logReceived)
+	require.Equal(t, filepath.Base(symLinkPath), e.Attributes["file_name"])
+	require.Equal(t, symLinkPath, e.Attributes["file_path"])
+	require.Equal(t, filepath.Base(resolved2), e.Attributes["file_name_resolved"])
+	require.Equal(t, resolved2, e.Attributes["file_path_resolved"])
+
+	// Clean up (linux based host)
+	// Ignore error on windows host (The process cannot access the file because it is being used by another process.)
+	os.RemoveAll(dir)
+}
+
 // ReadExistingLogs tests that, when starting from beginning, we
 // read all the lines that are already there
 func TestReadExistingLogs(t *testing.T) {

--- a/operator/builtin/input/file/reader.go
+++ b/operator/builtin/input/file/reader.go
@@ -26,19 +26,47 @@ import (
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/transform"
 
-	"github.com/open-telemetry/opentelemetry-log-collection/entry"
 	"github.com/open-telemetry/opentelemetry-log-collection/errors"
 )
+
+// File attributes contains information about file paths
+type fileAttributes struct {
+	Name         string
+	Path         string
+	ResolvedName string
+	ResolvedPath string
+}
+
+// resolveFileAttributes resolves file attributes
+// and sets it to empty string in case of error
+func resolveFileAttributes(path string) *fileAttributes {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		resolved = ""
+	}
+
+	abs, err := filepath.Abs(resolved)
+	if err != nil {
+		abs = ""
+	}
+
+	return &fileAttributes{
+		Path:         path,
+		Name:         filepath.Base(path),
+		ResolvedPath: abs,
+		ResolvedName: filepath.Base(abs),
+	}
+}
 
 // Reader manages a single file
 type Reader struct {
 	Fingerprint *Fingerprint
 	Offset      int64
-	Path        string
 
-	generation int
-	fileInput  *InputOperator
-	file       *os.File
+	generation     int
+	fileInput      *InputOperator
+	file           *os.File
+	fileAttributes *fileAttributes
 
 	decoder      *encoding.Decoder
 	decodeBuffer []byte
@@ -49,20 +77,25 @@ type Reader struct {
 // NewReader creates a new file reader
 func (f *InputOperator) NewReader(path string, file *os.File, fp *Fingerprint) (*Reader, error) {
 	r := &Reader{
-		Fingerprint:   fp,
-		file:          file,
-		Path:          path,
-		fileInput:     f,
-		SugaredLogger: f.SugaredLogger.With("path", path),
-		decoder:       f.encoding.Encoding.NewDecoder(),
-		decodeBuffer:  make([]byte, 1<<12),
+		Fingerprint:    fp,
+		file:           file,
+		fileInput:      f,
+		SugaredLogger:  f.SugaredLogger.With("path", path),
+		decoder:        f.encoding.Encoding.NewDecoder(),
+		decodeBuffer:   make([]byte, 1<<12),
+		fileAttributes: resolveFileAttributes(path),
 	}
 	return r, nil
 }
 
+// SetPath sets fileAttributes based on new path
+func (r *Reader) SetPath(path string) {
+	r.fileAttributes = resolveFileAttributes(path)
+}
+
 // Copy creates a deep copy of a Reader
 func (f *Reader) Copy(file *os.File) (*Reader, error) {
-	reader, err := f.fileInput.NewReader(f.Path, file, f.Fingerprint.Copy())
+	reader, err := f.fileInput.NewReader(f.fileAttributes.Path, file, f.Fingerprint.Copy())
 	if err != nil {
 		return nil, err
 	}
@@ -145,40 +178,22 @@ func (f *Reader) emit(ctx context.Context, msgBuf []byte) error {
 		return fmt.Errorf("create entry: %s", err)
 	}
 
-	if err := e.Set(f.fileInput.FilePathField, f.Path); err != nil {
+	if err := e.Set(f.fileInput.FilePathField, f.fileAttributes.Path); err != nil {
 		return err
 	}
-	if err := e.Set(f.fileInput.FileNameField, filepath.Base(f.Path)); err != nil {
+	if err := e.Set(f.fileInput.FileNameField, f.fileAttributes.Name); err != nil {
 		return err
 	}
-	if err := f.resolvePath(e); err != nil {
+
+	if err := e.Set(f.fileInput.FilePathResolvedField, f.fileAttributes.ResolvedPath); err != nil {
+		return err
+	}
+
+	if err := e.Set(f.fileInput.FileNameResolvedField, f.fileAttributes.ResolvedName); err != nil {
 		return err
 	}
 
 	f.fileInput.Write(ctx, e)
-	return nil
-}
-
-// resolvePath resolves path to real and absolute form and add them into entry
-func (f *Reader) resolvePath(e *entry.Entry) error {
-	resolved, err := filepath.EvalSymlinks(f.Path)
-	if err != nil {
-		return err
-	}
-
-	abs, err := filepath.Abs(resolved)
-	if err != nil {
-		return err
-	}
-
-	if err := e.Set(f.fileInput.FilePathResolvedField, abs); err != nil {
-		return err
-	}
-
-	if err := e.Set(f.fileInput.FileNameResolvedField, filepath.Base(abs)); err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Add `file_name_resolved` and `file_path_resolved` attributes. They are going to keep information about absolute path and file name after symlinks resolution

fixes #181 