### PR TITLE
Fix issue where log entry could be duplicated on parse error

### DIFF
--- a/operator/builtin/parser/csv/csv_test.go
+++ b/operator/builtin/parser/csv/csv_test.go
@@ -234,13 +234,13 @@ func TestParserCSVMultipleBodys(t *testing.T) {
 		entry := entry.New()
 		entry.Body = "stanza,INFO,started agent\nstanza,DEBUG,started agent"
 		err = op.Process(context.Background(), entry)
-		require.Nil(t, err, "Expected to parse a single csv record, got '2'")
 		require.NoError(t, err)
 		fake.ExpectBody(t, map[string]interface{}{
 			"name": "stanza",
 			"sev":  "INFO",
 			"msg":  "started agent",
 		})
+		fake.ExpectNoEntry(t, 100*time.Millisecond)
 	})
 }
 
@@ -260,7 +260,7 @@ func TestParserCSVInvalidJSONInput(t *testing.T) {
 		entry := entry.New()
 		entry.Body = "{\"name\": \"stanza\"}"
 		err = op.Process(context.Background(), entry)
-		require.Nil(t, err, "parse error on line 1, column 1: bare \" in non-quoted-field")
+		require.Error(t, err, "parse error on line 1, column 1: bare \" in non-quoted-field")
 		fake.ExpectBody(t, "{\"name\": \"stanza\"}")
 	})
 }

--- a/operator/helper/transformer.go
+++ b/operator/helper/transformer.go
@@ -111,7 +111,6 @@ func (t *TransformerOperator) HandleEntryError(ctx context.Context, entry *entry
 	t.Errorw("Failed to process entry", zap.Any("error", err), zap.Any("action", t.OnError), zap.Any("entry", entry))
 	if t.OnError == SendOnError {
 		t.Write(ctx, entry)
-		return nil
 	}
 	return err
 }

--- a/testutil/mocks.go
+++ b/testutil/mocks.go
@@ -110,3 +110,13 @@ func (f *FakeOutput) ExpectEntry(t testing.TB, expected *entry.Entry) {
 		require.FailNow(t, "Timed out waiting for entry")
 	}
 }
+
+// ExpectNoEntry expects that no entry will be received within the specified time
+func (f *FakeOutput) ExpectNoEntry(t testing.TB, timeout time.Duration) {
+	select {
+	case <-f.Received:
+		require.FailNow(t, "Should not have received entry")
+	case <-time.After(timeout):
+		return
+	}
+}


### PR DESCRIPTION
Resolved #187 

`Transformer.HandleEntryError` is responsible for the following:
1. Log that an error occurred
2. Send (`next.Process(entry)`) or Drop the entry which encountered the error
3. Return the error

The responsibility of this method to return the error which it was given is a little odd. However, in practice it is a helpful way for callers to bail out. (`return t.HandleEntryError(..., err)`)

The problem, was that the method did not return the error when on_error=send. In some cases, the lack of an error was interpreted as a signal to continue processing of the entry, which ultimately resulted in a second call to `next.Process(entry)`.

This PR clarifies the expectation that `on_error` does not affect whether or not an error is returned when encountered. `on_error` only affects whether or not the entry that caused the error is passed along or not.

Aside from preventing this bug, and reworking the associated expectations in test cases, there should be no effect from this change. The error is ultimately dropped when `next.Process` returns.

