### PR TITLE
Delete unnecessary FingerprintUpdatingReader

### DIFF
--- a/operator/builtin/input/file/file_test.go
+++ b/operator/builtin/input/file/file_test.go
@@ -635,6 +635,66 @@ func TestFileReader_FingerprintUpdated(t *testing.T) {
 	require.Equal(t, []byte("testlog1\n"), reader.Fingerprint.FirstBytes)
 }
 
+// Test that a fingerprint:
+// - Starts empty
+// - Updates as a file is read
+// - Stops updating when the max fingerprint size is reached
+// - Stops exactly at max fingerprint size, regardless of content
+func TestFingerprintGrowsAndStops(t *testing.T) {
+	t.Parallel()
+
+	// Use a number with many factors.
+	// Sometimes fingerprint length will align with
+	// the end of a line, sometimes not. Test both.
+	maxFP := 360
+
+	// Use prime numbers to ensure variation in
+	// whether or not they are factors of maxFP
+	lineLens := []int{3, 5, 7, 11, 13, 17, 19, 23, 27}
+
+	for _, lineLen := range lineLens {
+		t.Run(fmt.Sprintf("%d", lineLen), func(t *testing.T) {
+			t.Parallel()
+			operator, _, tempDir := newTestFileOperator(t, func(cfg *InputConfig) {
+				cfg.FingerprintSize = helper.ByteSize(maxFP)
+			}, nil)
+			defer operator.Stop()
+
+			temp := openTemp(t, tempDir)
+			tempCopy := openFile(t, temp.Name())
+			fp, err := operator.NewFingerprint(temp)
+			require.NoError(t, err)
+			require.Equal(t, []byte(""), fp.FirstBytes)
+
+			reader, err := operator.NewReader(temp.Name(), tempCopy, fp)
+			require.NoError(t, err)
+			defer reader.Close()
+
+			// keep track of what has been written to the file
+			fileContent := []byte{}
+
+			// keep track of expected fingerprint size
+			expectedFP := 0
+
+			// Write lines until file is much larger than the length of the fingerprint
+			for len(fileContent) < 2*maxFP {
+				expectedFP += lineLen
+				if expectedFP > maxFP {
+					expectedFP = maxFP
+				}
+
+				line := stringWithLength(lineLen-1) + "\n"
+				fileContent = append(fileContent, []byte(line)...)
+
+				writeString(t, temp, line)
+				reader.ReadToEnd(context.Background())
+				require.Equal(t, []byte(fileContent[:expectedFP]), reader.Fingerprint.FirstBytes)
+			}
+		})
+	}
+
+}
+
 func TestEncodings(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/operator/builtin/input/file/file_test.go
+++ b/operator/builtin/input/file/file_test.go
@@ -688,11 +688,10 @@ func TestFingerprintGrowsAndStops(t *testing.T) {
 
 				writeString(t, temp, line)
 				reader.ReadToEnd(context.Background())
-				require.Equal(t, []byte(fileContent[:expectedFP]), reader.Fingerprint.FirstBytes)
+				require.Equal(t, fileContent[:expectedFP], reader.Fingerprint.FirstBytes)
 			}
 		})
 	}
-
 }
 
 func TestEncodings(t *testing.T) {

--- a/operator/builtin/input/file/reader.go
+++ b/operator/builtin/input/file/reader.go
@@ -59,9 +59,8 @@ func (f *InputOperator) resolveFileAttributes(path string) *fileAttributes {
 
 // Reader manages a single file
 type Reader struct {
-	Fingerprint     *Fingerprint
-	fingerprintSize int
-	Offset          int64
+	Fingerprint *Fingerprint
+	Offset      int64
 
 	generation     int
 	fileInput      *InputOperator
@@ -77,14 +76,13 @@ type Reader struct {
 // NewReader creates a new file reader
 func (f *InputOperator) NewReader(path string, file *os.File, fp *Fingerprint) (*Reader, error) {
 	r := &Reader{
-		Fingerprint:     fp,
-		fingerprintSize: f.fingerprintSize,
-		file:            file,
-		fileInput:       f,
-		SugaredLogger:   f.SugaredLogger.With("path", path),
-		decoder:         f.encoding.Encoding.NewDecoder(),
-		decodeBuffer:    make([]byte, 1<<12),
-		fileAttributes:  f.resolveFileAttributes(path),
+		Fingerprint:    fp,
+		file:           file,
+		fileInput:      f,
+		SugaredLogger:  f.SugaredLogger.With("path", path),
+		decoder:        f.encoding.Encoding.NewDecoder(),
+		decodeBuffer:   make([]byte, 1<<12),
+		fileAttributes: f.resolveFileAttributes(path),
 	}
 	return r, nil
 }
@@ -214,13 +212,13 @@ func getScannerError(scanner *PositionalScanner) error {
 	return nil
 }
 
-// Read reads from the wrapped reader, saving the read bytes to the fingerprint
+// Read from the file and update the fingerprint if necessary
 func (f *Reader) Read(dst []byte) (int, error) {
-	if len(f.Fingerprint.FirstBytes) == f.fingerprintSize {
+	if len(f.Fingerprint.FirstBytes) == f.fileInput.fingerprintSize {
 		return f.file.Read(dst)
 	}
 	n, err := f.file.Read(dst)
-	appendCount := min0(n, f.fingerprintSize-int(f.Offset))
+	appendCount := min0(n, f.fileInput.fingerprintSize-int(f.Offset))
 	f.Fingerprint.FirstBytes = append(f.Fingerprint.FirstBytes[:f.Offset], dst[:appendCount]...)
 	return n, err
 }


### PR DESCRIPTION
As part of an ongoing effort to simplify the `file_input` operator, this PR removes a struct called `FingerprintUpdatingReader`. This struct wrapped a `Reader` and managed the `Reader` fingerprint. However, a `Reader` can manage its own  fingerprint just fine.