### PR TITLE
fix(input/file,docs): fix typo for file attributes names

### DIFF
--- a/docs/operators/file_input.md
+++ b/docs/operators/file_input.md
@@ -14,10 +14,10 @@ The `file_input` operator reads logs from files. It will place the lines read in
 | `multiline`                     |                  | A `multiline` configuration block. See below for details                                                           |
 | `write_to`                      | `$body`          | The body [field](/docs/types/field.md) written to when creating a new log entry                                    |
 | `encoding`                      | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options               |
-| `include_file_name`             | `true`           | Whether to add the file name as the attribute `file_name`                                                          |
-| `include_file_path`             | `false`          | Whether to add the file path as the attribute `file_path`                                                          |
-| `include_file_name_resolved`    | `false`          | Whether to add the file name after symlinks resolution as the attribute `file_name_resolved`                       |
-| `include_file_path_resolved`    | `false`          | Whether to add the file path after symlinks resolution as the attribute `file_path_resolved`                       |
+| `include_file_name`             | `true`           | Whether to add the file name as the attribute `file.name`                                                          |
+| `include_file_path`             | `false`          | Whether to add the file path as the attribute `file.path`                                                          |
+| `include_file_name_resolved`    | `false`          | Whether to add the file name after symlinks resolution as the attribute `file.name.resolved`                       |
+| `include_file_path_resolved`    | `false`          | Whether to add the file path after symlinks resolution as the attribute `file.path.resolved`                       |
 | `start_at`                      | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
 | `fingerprint_size`              | `1kb`            | The number of bytes with which to identify a file. The first bytes in the file are used as the fingerprint. Decreasing this value at any point will cause existing fingerprints to forgotten, meaning that all files will be read from the beginning (one time). |
 | `max_log_size`                  | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |


### PR DESCRIPTION
fix typo for file attributes names