### PR TITLE
Fix formatting error when input file operator fails to close the file

### DIFF
--- a/operator/builtin/input/file/reader.go
+++ b/operator/builtin/input/file/reader.go
@@ -154,7 +154,7 @@ func (r *Reader) ReadToEnd(ctx context.Context) {
 func (r *Reader) Close() {
 	if r.file != nil {
 		if err := r.file.Close(); err != nil {
-			r.Debugf("Problem closing reader", "Error", err.Error())
+			r.Debugw("Problem closing reader", zap.Error(err))
 		}
 	}
 }


### PR DESCRIPTION
This change changes this:

```
2021-08-30T15:43:10.945+0200    debug   Problem closing reader%!(EXTRA zapcore.Field={error 26 0  close collector.log: file already closed})    {"kind": "receiver", "name": "filelog", "operator_id": "$.file_input", "operator_type": "file_input", "path": "collector.log"}
```

into:

```
2021-08-30T18:00:19.147+0200    debug   Problem closing reader  {"kind": "receiver", "name": "filelog", "operator_id": "$.file_input", "operator_type": "file_input", "path": "collector.log", "error": "close collector.log: file already closed"}
```