### PR TITLE
URI Parser Tests

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -8,7 +8,7 @@ env:
   # Path to where test results will be saved.
   TEST_RESULTS: /tmp/test-results
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: 1.15
+  DEFAULT_GO_VERSION: 1.17
 jobs:
   test-coverage:
     runs-on: ubuntu-latest

--- a/operator/builtin/parser/uri/config_test.go
+++ b/operator/builtin/parser/uri/config_test.go
@@ -1,0 +1,106 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package uri
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-log-collection/entry"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper/operatortest"
+)
+
+func TestRegexParserGoldenConfig(t *testing.T) {
+	cases := []operatortest.ConfigUnmarshalTest{
+		{
+			Name:   "default",
+			Expect: defaultCfg(),
+		},
+		{
+			Name: "parse_from_simple",
+			Expect: func() *URIParserConfig {
+				cfg := defaultCfg()
+				cfg.ParseFrom = entry.NewBodyField("from")
+				return cfg
+			}(),
+		},
+		{
+			Name: "parse_to_simple",
+			Expect: func() *URIParserConfig {
+				cfg := defaultCfg()
+				cfg.ParseTo = entry.NewBodyField("log")
+				return cfg
+			}(),
+		},
+		{
+			Name: "on_error_drop",
+			Expect: func() *URIParserConfig {
+				cfg := defaultCfg()
+				cfg.OnError = "drop"
+				return cfg
+			}(),
+		},
+		{
+			Name: "timestamp",
+			Expect: func() *URIParserConfig {
+				cfg := defaultCfg()
+				parseField := entry.NewBodyField("timestamp_field")
+				newTime := helper.TimeParser{
+					LayoutType: "strptime",
+					Layout:     "%Y-%m-%d",
+					ParseFrom:  &parseField,
+				}
+				cfg.TimeParser = &newTime
+				return cfg
+			}(),
+		},
+		{
+			Name: "severity",
+			Expect: func() *URIParserConfig {
+				cfg := defaultCfg()
+				parseField := entry.NewBodyField("severity_field")
+				severityField := helper.NewSeverityParserConfig()
+				severityField.ParseFrom = &parseField
+				mapping := map[interface{}]interface{}{
+					"critical": "5xx",
+					"error":    "4xx",
+					"info":     "3xx",
+					"debug":    "2xx",
+				}
+				severityField.Mapping = mapping
+				cfg.SeverityParserConfig = &severityField
+				return cfg
+			}(),
+		},
+		{
+			Name: "preserve_to",
+			Expect: func() *URIParserConfig {
+				cfg := defaultCfg()
+				preserve := entry.NewBodyField("aField")
+				cfg.PreserveTo = &preserve
+				return cfg
+			}(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			tc.Run(t, defaultCfg())
+		})
+	}
+}
+
+func defaultCfg() *URIParserConfig {
+	return NewURIParserConfig("uri_parser")
+}

--- a/operator/builtin/parser/uri/testdata/default.yaml
+++ b/operator/builtin/parser/uri/testdata/default.yaml
@@ -1,0 +1,1 @@
+type: uri_parser

--- a/operator/builtin/parser/uri/testdata/on_error_drop.yaml
+++ b/operator/builtin/parser/uri/testdata/on_error_drop.yaml
@@ -1,0 +1,2 @@
+type: uri_parser
+on_error: "drop"

--- a/operator/builtin/parser/uri/testdata/parse_from_simple.yaml
+++ b/operator/builtin/parser/uri/testdata/parse_from_simple.yaml
@@ -1,0 +1,2 @@
+type: uri_parser
+parse_from: "$.from"

--- a/operator/builtin/parser/uri/testdata/parse_to_simple.yaml
+++ b/operator/builtin/parser/uri/testdata/parse_to_simple.yaml
@@ -1,0 +1,2 @@
+type: uri_parser
+parse_to: "log"

--- a/operator/builtin/parser/uri/testdata/preserve_to.yaml
+++ b/operator/builtin/parser/uri/testdata/preserve_to.yaml
@@ -1,0 +1,2 @@
+type: uri_parser
+preserve_to: "aField"

--- a/operator/builtin/parser/uri/testdata/severity.yaml
+++ b/operator/builtin/parser/uri/testdata/severity.yaml
@@ -1,0 +1,8 @@
+type: uri_parser
+severity:
+  parse_from: severity_field
+  mapping:
+    critical: 5xx
+    error: 4xx
+    info: 3xx
+    debug: 2xx

--- a/operator/builtin/parser/uri/testdata/timestamp.yaml
+++ b/operator/builtin/parser/uri/testdata/timestamp.yaml
@@ -1,0 +1,5 @@
+type: uri_parser
+timestamp:
+  parse_from: timestamp_field
+  layout_type: strptime
+  layout: '%Y-%m-%d'


### PR DESCRIPTION
- added golden config tests
- added tests for process
- test coverage 93% -> 100%
- bumped code cov go version from 1.15 to 1.17. It appears Go 1.15 does not fail to parse invalid URI's the way Go 1.17 does.