### PR TITLE
Fix syslog severity mapping to be in line with specification

### DIFF
--- a/operator/builtin/parser/syslog/syslog.go
+++ b/operator/builtin/parser/syslog/syslog.go
@@ -224,7 +224,7 @@ var severityMapping = [...]entry.Severity{
 	2: entry.Error2,
 	3: entry.Error,
 	4: entry.Warn,
-	5: entry.Info3,
+	5: entry.Info2,
 	6: entry.Info,
 	7: entry.Debug,
 }


### PR DESCRIPTION
According to [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#appendix-b-severitynumber-example-mappings), syslog `notice` should be regarded as `INFO2`. Closes #297