### PR TITLE
Fix bug where splitting could be skipped

### DIFF
--- a/operator/helper/multiline_test.go
+++ b/operator/helper/multiline_test.go
@@ -412,6 +412,18 @@ func TestNewlineSplitFunc(t *testing.T) {
 				lastForcedFlush: time.Now(),
 			},
 		},
+		{
+			Name: "DefaultFlusherSplits",
+			Raw:  []byte("log1\nlog2\n"),
+			ExpectedTokenized: []string{
+				"log1",
+				"log2",
+			},
+			Flusher: &Flusher{
+				force:           true,
+				lastForcedFlush: time.Now(),
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Resolves #292 

When force_flush_period is set to a non-zero value,
a forced flushing operation would disregard the possibility
that the data being flushed may contain multiple entries.

For example, the file_input operator could flush the remainder
of a file that it was consuming. If multiple lines were written
to that file, they would be emitted as a single log entry.

The fix is basically that when a forced flush is required, we
will continue reading in lines until reaching the end of file.
Only then will we mark the flush complete.