### PR TITLE
docs: remove duplicate list entry

### DIFF
--- a/docs/operators/README.md
+++ b/docs/operators/README.md
@@ -34,7 +34,6 @@ Outputs:
 General purpose:
 - [add](/docs/operators/add.md)
 - [copy](/docs/operators/copy.md)
-- [flatten](/docs/operators/flatten.md)
 - [filter](/docs/operators/filter.md)
 - [flatten](/docs/operators/flatten.md)
 - [metadata](/docs/operators/metadata.md)


### PR DESCRIPTION
Just a tiny fix noticed while reading the docs - the `flatten` operator appears twice in the list of operators.