### PR TITLE
fix(recombine)!: change default operator type

### DIFF
--- a/docs/operators/recombine.md
+++ b/docs/operators/recombine.md
@@ -6,7 +6,7 @@ The `recombine` operator combines consecutive logs into single logs based on sim
 
 | Field            | Default          | Description |
 | ---              | ---              | ---         |
-| `id`             | `metadata`       | A unique identifier for the operator. |
+| `id`             | `recombine`      | A unique identifier for the operator. |
 | `output`         | Next in pipeline | The connected operator(s) that will receive all outbound entries. |
 | `on_error`       | `send`           | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md). |
 | `is_first_entry` |                  | An [expression](/docs/types/expression.md) that returns true if the entry being processed is the first entry in a multiline series. |

--- a/operator/builtin/transformer/recombine/recombine.go
+++ b/operator/builtin/transformer/recombine/recombine.go
@@ -36,7 +36,7 @@ func init() {
 // NewRecombineOperatorConfig creates a new recombine config with default values
 func NewRecombineOperatorConfig(operatorID string) *RecombineOperatorConfig {
 	return &RecombineOperatorConfig{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "metadata"),
+		TransformerConfig: helper.NewTransformerConfig(operatorID, "recombine"),
 		MaxBatchSize:      1000,
 		OverwriteWith:     "oldest",
 	}


### PR DESCRIPTION
Here's a small inconsistency that I've found in the `recombine` operator. Can we fix it? Note that it is technically a breaking change.

When declaring a `recombine` operator in configuration without specifying the `id`, the default operator ID is `metadata`. I imagine this can cause issues when user configures both an actual `metadata` operator and `recombine` operator, both of them without their `id`s.

BREAKING CHANGE: The default operator ID for `recombine` operator is now `recombine`, not `metadata`.