### PR TITLE
Update csv parser

### DIFF
--- a/operator/builtin/parser/csv/csv_test.go
+++ b/operator/builtin/parser/csv/csv_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator"
-	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
 	"github.com/open-telemetry/opentelemetry-log-collection/testutil"
 )
 
@@ -51,14 +50,23 @@ func TestCSVParserBuildFailureInvalidDelimiter(t *testing.T) {
 	cfg.FieldDelimiter = ";;"
 	_, err := cfg.Build(testutil.NewBuildContext(t))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Invalid 'delimiter': ';;'")
+	require.Contains(t, err.Error(), "invalid 'delimiter': ';;'")
+}
+
+func TestCSVParserBuildFailureBadHeaderConfig(t *testing.T) {
+	cfg := NewCSVParserConfig("test")
+	cfg.Header = "testheader"
+	cfg.HeaderAttribute = "testheader"
+	_, err := cfg.Build(testutil.NewBuildContext(t))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "only one header parameter can be set: 'header' or 'header_attribute'")
 }
 
 func TestCSVParserByteFailure(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse([]byte("invalid"))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "type '[]uint8' cannot be parsed as csv")
+	require.Contains(t, err.Error(), "record on line 1: wrong number of fields")
 }
 
 func TestCSVParserStringFailure(t *testing.T) {
@@ -77,22 +85,68 @@ func TestCSVParserInvalidType(t *testing.T) {
 
 func TestParserCSV(t *testing.T) {
 	cases := []struct {
-		name       string
-		configure  func(*CSVParserConfig)
-		inputBody  interface{}
-		outputBody interface{}
+		name             string
+		configure        func(*CSVParserConfig)
+		inputEntry       []entry.Entry
+		outputBody       []interface{}
+		expectBuildErr   bool
+		expectProcessErr bool
 	}{
 		{
 			"basic",
 			func(p *CSVParserConfig) {
 				p.Header = testHeader
 			},
-			"stanza,INFO,started agent",
-			map[string]interface{}{
-				"name": "stanza",
-				"sev":  "INFO",
-				"msg":  "started agent",
+			[]entry.Entry{
+				{
+					Body: "stanza,INFO,started agent",
+				},
 			},
+			[]interface{}{
+				map[string]interface{}{
+					"name": "stanza",
+					"sev":  "INFO",
+					"msg":  "started agent",
+				},
+			},
+			false,
+			false,
+		},
+		{
+			"basic-multiple-static-bodies",
+			func(p *CSVParserConfig) {
+				p.Header = testHeader
+			},
+			[]entry.Entry{
+				{
+					Body: "stanza,INFO,started agent",
+				},
+				{
+					Body: "stanza,ERROR,agent killed",
+				},
+				{
+					Body: "kernel,TRACE,oom",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"name": "stanza",
+					"sev":  "INFO",
+					"msg":  "started agent",
+				},
+				map[string]interface{}{
+					"name": "stanza",
+					"sev":  "ERROR",
+					"msg":  "agent killed",
+				},
+				map[string]interface{}{
+					"name": "kernel",
+					"sev":  "TRACE",
+					"msg":  "oom",
+				},
+			},
+			false,
+			false,
 		},
 		{
 			"advanced",
@@ -100,52 +154,213 @@ func TestParserCSV(t *testing.T) {
 				p.Header = "name;address;age;phone;position"
 				p.FieldDelimiter = ";"
 			},
-			"stanza;Evergreen;1;555-5555;agent",
-			map[string]interface{}{
-				"name":     "stanza",
-				"address":  "Evergreen",
-				"age":      "1",
-				"phone":    "555-5555",
-				"position": "agent",
+			[]entry.Entry{
+				{
+					Body: "stanza;Evergreen;1;555-5555;agent",
+				},
 			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":     "stanza",
+					"address":  "Evergreen",
+					"age":      "1",
+					"phone":    "555-5555",
+					"position": "agent",
+				},
+			},
+			false,
+			false,
+		},
+		{
+			"dynamic-fields",
+			func(p *CSVParserConfig) {
+				p.HeaderAttribute = "Fields"
+				p.FieldDelimiter = ","
+			},
+			[]entry.Entry{
+				{
+					Attributes: map[string]string{
+						"Fields": "name,age,height,number",
+					},
+					Body: "stanza dev,1,400,555-555-5555",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":   "stanza dev",
+					"age":    "1",
+					"height": "400",
+					"number": "555-555-5555",
+				},
+			},
+			false,
+			false,
+		},
+		{
+			"dynamic-fields-multiple-entries",
+			func(p *CSVParserConfig) {
+				p.HeaderAttribute = "Fields"
+				p.FieldDelimiter = ","
+			},
+			[]entry.Entry{
+				{
+					Attributes: map[string]string{
+						"Fields": "name,age,height,number",
+					},
+					Body: "stanza dev,1,400,555-555-5555",
+				},
+				{
+					Attributes: map[string]string{
+						"Fields": "x,y",
+					},
+					Body: "000100,2",
+				},
+				{
+					Attributes: map[string]string{
+						"Fields": "a,b,c,d,e,f",
+					},
+					Body: "1,2,3,4,5,6",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":   "stanza dev",
+					"age":    "1",
+					"height": "400",
+					"number": "555-555-5555",
+				},
+				map[string]interface{}{
+					"x": "000100",
+					"y": "2",
+				},
+				map[string]interface{}{
+					"a": "1",
+					"b": "2",
+					"c": "3",
+					"d": "4",
+					"e": "5",
+					"f": "6",
+				},
+			},
+			false,
+			false,
+		},
+		{
+			"dynamic-fields-tab",
+			func(p *CSVParserConfig) {
+				p.HeaderAttribute = "columns"
+				p.FieldDelimiter = "\t"
+			},
+			[]entry.Entry{
+				{
+					Attributes: map[string]string{
+						"columns": "name	age	height	number",
+					},
+					Body: "stanza dev	1	400	555-555-5555",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":   "stanza dev",
+					"age":    "1",
+					"height": "400",
+					"number": "555-555-5555",
+				},
+			},
+			false,
+			false,
+		},
+		{
+			"dynamic-fields-label-missing",
+			func(p *CSVParserConfig) {
+				p.HeaderAttribute = "Fields"
+				p.FieldDelimiter = ","
+			},
+			[]entry.Entry{
+				{
+					Body: "stanza dev,1,400,555-555-5555",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":   "stanza dev",
+					"age":    "1",
+					"height": "400",
+					"number": "555-555-5555",
+				},
+			},
+			false,
+			true,
+		},
+		{
+			"missing-header-field",
+			func(p *CSVParserConfig) {
+				p.FieldDelimiter = ","
+			},
+			[]entry.Entry{
+				{
+					Body: "stanza,1,400,555-555-5555",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":   "stanza",
+					"age":    "1",
+					"height": "400",
+					"number": "555-555-5555",
+				},
+			},
+			true,
+			false,
 		},
 		{
 			"mariadb-audit-log",
 			func(p *CSVParserConfig) {
 				p.Header = "timestamp,serverhost,username,host,connectionid,queryid,operation,database,object,retcode"
-				tp := helper.NewTimeParser()
-				field := entry.NewBodyField("timestamp")
-				tp.ParseFrom = &field
-				tp.LayoutType = "strptime"
-				tp.Layout = "%Y%m%d"
-				p.TimeParser = &tp
 			},
-			"20210316,oiq-int-mysql,load,oiq-int-mysql.bluemedora.localnet,5,0,DISCONNECT,,,0",
-			map[string]interface{}{
-				"serverhost":   "oiq-int-mysql",
-				"username":     "load",
-				"host":         "oiq-int-mysql.bluemedora.localnet",
-				"connectionid": "5",
-				"queryid":      "0",
-				"operation":    "DISCONNECT",
-				"database":     "",
-				"object":       "",
-				"retcode":      "0",
+			[]entry.Entry{
+				{
+					Body: "20210316 17:08:01,oiq-int-mysql,load,oiq-int-mysql.bluemedora.localnet,5,0,DISCONNECT,,,0",
+				},
 			},
+			[]interface{}{
+				map[string]interface{}{
+					"timestamp":    "20210316 17:08:01",
+					"serverhost":   "oiq-int-mysql",
+					"username":     "load",
+					"host":         "oiq-int-mysql.bluemedora.localnet",
+					"connectionid": "5",
+					"queryid":      "0",
+					"operation":    "DISCONNECT",
+					"database":     "",
+					"object":       "",
+					"retcode":      "0",
+				},
+			},
+			false,
+			false,
 		},
 		{
 			"empty field",
 			func(p *CSVParserConfig) {
 				p.Header = "name,address,age,phone,position"
 			},
-			"stanza,Evergreen,,555-5555,agent",
-			map[string]interface{}{
-				"name":     "stanza",
-				"address":  "Evergreen",
-				"age":      "",
-				"phone":    "555-5555",
-				"position": "agent",
+			[]entry.Entry{
+				{
+					Body: "stanza,Evergreen,,555-5555,agent",
+				},
 			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":     "stanza",
+					"address":  "Evergreen",
+					"age":      "",
+					"phone":    "555-5555",
+					"position": "agent",
+				},
+			},
+			false,
+			false,
 		},
 		{
 			"tab delimiter",
@@ -153,42 +368,178 @@ func TestParserCSV(t *testing.T) {
 				p.Header = "name	address	age	phone	position"
 				p.FieldDelimiter = "\t"
 			},
-			"stanza	Evergreen	1	555-5555	agent",
-			map[string]interface{}{
-				"name":     "stanza",
-				"address":  "Evergreen",
-				"age":      "1",
-				"phone":    "555-5555",
-				"position": "agent",
+			[]entry.Entry{
+				{
+					Body: "stanza	Evergreen	1	555-5555	agent",
+				},
 			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":     "stanza",
+					"address":  "Evergreen",
+					"age":      "1",
+					"phone":    "555-5555",
+					"position": "agent",
+				},
+			},
+			false,
+			false,
 		},
 		{
 			"comma in quotes",
 			func(p *CSVParserConfig) {
 				p.Header = "name,address,age,phone,position"
 			},
-			"stanza,\"Evergreen,49508\",1,555-5555,agent",
-			map[string]interface{}{
-				"name":     "stanza",
-				"address":  "Evergreen,49508",
-				"age":      "1",
-				"phone":    "555-5555",
-				"position": "agent",
+			[]entry.Entry{
+				{
+					Body: "stanza,\"Evergreen,49508\",1,555-5555,agent",
+				},
 			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":     "stanza",
+					"address":  "Evergreen,49508",
+					"age":      "1",
+					"phone":    "555-5555",
+					"position": "agent",
+				},
+			},
+			false,
+			false,
 		},
 		{
 			"quotes in quotes",
 			func(p *CSVParserConfig) {
 				p.Header = "name,address,age,phone,position"
 			},
-			"\"bob \"\"the man\"\"\",Evergreen,1,555-5555,agent",
-			map[string]interface{}{
-				"name":     "bob \"the man\"",
-				"address":  "Evergreen",
-				"age":      "1",
-				"phone":    "555-5555",
-				"position": "agent",
+			[]entry.Entry{
+				{
+					Body: "\"bob \"\"the man\"\"\",Evergreen,1,555-5555,agent",
+				},
 			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":     "bob \"the man\"",
+					"address":  "Evergreen",
+					"age":      "1",
+					"phone":    "555-5555",
+					"position": "agent",
+				},
+			},
+			false,
+			false,
+		},
+		{
+			"missing-header-delimiter-in-header",
+			func(p *CSVParserConfig) {
+				p.Header = "name:age:height:number"
+				p.FieldDelimiter = ","
+			},
+			[]entry.Entry{
+				{
+					Body: "stanza,1,400,555-555-5555",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":   "stanza",
+					"age":    "1",
+					"height": "400",
+					"number": "555-555-5555",
+				},
+			},
+			true,
+			false,
+		},
+		{
+			"invalid-delimiter",
+			func(p *CSVParserConfig) {
+				// expect []rune of length 1
+				p.Header = "name,,age,,height,,number"
+				p.FieldDelimiter = ",,"
+			},
+			[]entry.Entry{
+				{
+					Body: "stanza,1,400,555-555-5555",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":   "stanza",
+					"age":    "1",
+					"height": "400",
+					"number": "555-555-5555",
+				},
+			},
+			true,
+			false,
+		},
+		{
+			"parse-failure-num-fields-mismatch",
+			func(p *CSVParserConfig) {
+				p.Header = "name,age,height,number"
+				p.FieldDelimiter = ","
+			},
+			[]entry.Entry{
+				{
+					Body: "1,400,555-555-5555",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":   "stanza",
+					"age":    "1",
+					"height": "400",
+					"number": "555-555-5555",
+				},
+			},
+			false,
+			true,
+		},
+		{
+			"parse-failure-wrong-field-delimiter",
+			func(p *CSVParserConfig) {
+				p.Header = "name,age,height,number"
+				p.FieldDelimiter = ","
+			},
+			[]entry.Entry{
+				{
+					Body: "stanza:1:400:555-555-5555",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":   "stanza",
+					"age":    "1",
+					"height": "400",
+					"number": "555-555-5555",
+				},
+			},
+			false,
+			true,
+		},
+		{
+			"parse-with-lazy-quotes",
+			func(p *CSVParserConfig) {
+				p.Header = "name,age,height,number"
+				p.FieldDelimiter = ","
+				p.LazyQuotes = true
+			},
+			[]entry.Entry{
+				{
+					Body: "stanza \"log parser\",1,6ft,5",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"name":   "stanza \"log parser\"",
+					"age":    "1",
+					"height": "6ft",
+					"number": "5",
+				},
+			},
+			false,
+			false,
 		},
 	}
 
@@ -199,26 +550,31 @@ func TestParserCSV(t *testing.T) {
 			tc.configure(cfg)
 
 			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			if tc.expectBuildErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			op := ops[0]
 
 			fake := testutil.NewFakeOutput(t)
 			op.SetOutputs([]operator.Operator{fake})
 
-			entry := entry.New()
-			entry.Body = tc.inputBody
-			err = op.Process(context.Background(), entry)
-			require.NoError(t, err)
-			if cfg.TimeParser != nil {
-				newTime, _ := time.ParseInLocation("20060102", "20210316", entry.Timestamp.Location())
-				require.Equal(t, newTime, entry.Timestamp)
+			for i, inputEntry := range tc.inputEntry {
+				err = op.Process(context.Background(), &inputEntry)
+				if tc.expectProcessErr {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+
+				fake.ExpectBody(t, tc.outputBody[i])
 			}
-			fake.ExpectBody(t, tc.outputBody)
 		})
 	}
 }
 
-func TestParserCSVMultipleBodys(t *testing.T) {
+func TestParserCSVMultipleBodies(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		cfg := NewCSVParserConfig("test")
 		cfg.OutputIDs = []string{"fake"}
@@ -237,7 +593,7 @@ func TestParserCSVMultipleBodys(t *testing.T) {
 		require.NoError(t, err)
 		fake.ExpectBody(t, map[string]interface{}{
 			"name": "stanza",
-			"sev":  "INFO",
+			"sev":  "DEBUG",
 			"msg":  "started agent",
 		})
 		fake.ExpectNoEntry(t, 100*time.Millisecond)


### PR DESCRIPTION
- Added configuration support for Lazy Quotes
- Added configuration for a HeaderAttribute to support pulling header fields from an attribute on an entry. This is a pattern seen in W3C log format primarily for Microsoft IIS logging.
  - Due to headerAttribute creating generateParseFunc to dynamically create a parser function based on the HeaderAttribute
- Lower cased errors in csv to be in line with idiomatic Go