### PR TITLE
CSV Idiomatic Errors

### DIFF
--- a/operator/builtin/parser/csv/csv.go
+++ b/operator/builtin/parser/csv/csv.go
@@ -51,7 +51,7 @@ func (c CSVParserConfig) Build(context operator.BuildContext) ([]operator.Operat
 	}
 
 	if c.Header == "" {
-		return nil, fmt.Errorf("Missing required field 'header'")
+		return nil, fmt.Errorf("missing required field 'header'")
 	}
 
 	if c.FieldDelimiter == "" {
@@ -59,7 +59,7 @@ func (c CSVParserConfig) Build(context operator.BuildContext) ([]operator.Operat
 	}
 
 	if len([]rune(c.FieldDelimiter)) != 1 {
-		return nil, fmt.Errorf("Invalid 'delimiter': '%s'", c.FieldDelimiter)
+		return nil, fmt.Errorf("invalid 'delimiter': '%s'", c.FieldDelimiter)
 	}
 
 	fieldDelimiter := []rune(c.FieldDelimiter)[0]

--- a/operator/builtin/parser/csv/csv.go
+++ b/operator/builtin/parser/csv/csv.go
@@ -16,6 +16,7 @@ package csv
 import (
 	"context"
 	csvparser "encoding/csv"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -51,7 +52,7 @@ func (c CSVParserConfig) Build(context operator.BuildContext) ([]operator.Operat
 	}
 
 	if c.Header == "" {
-		return nil, fmt.Errorf("missing required field 'header'")
+		return nil, errors.New("missing required field 'header'")
 	}
 
 	if c.FieldDelimiter == "" {
@@ -65,7 +66,7 @@ func (c CSVParserConfig) Build(context operator.BuildContext) ([]operator.Operat
 	fieldDelimiter := []rune(c.FieldDelimiter)[0]
 
 	if !strings.Contains(c.Header, c.FieldDelimiter) {
-		return nil, fmt.Errorf("missing field delimiter in header")
+		return nil, errors.New("missing field delimiter in header")
 	}
 
 	numFields := len(strings.Split(c.Header, c.FieldDelimiter))

--- a/operator/builtin/parser/csv/csv_test.go
+++ b/operator/builtin/parser/csv/csv_test.go
@@ -51,7 +51,7 @@ func TestCSVParserBuildFailureInvalidDelimiter(t *testing.T) {
 	cfg.FieldDelimiter = ";;"
 	_, err := cfg.Build(testutil.NewBuildContext(t))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Invalid 'delimiter': ';;'")
+	require.Contains(t, err.Error(), "invalid 'delimiter': ';;'")
 }
 
 func TestCSVParserByteFailure(t *testing.T) {


### PR DESCRIPTION
- Changed errors in CSV parser operator to have lowercase first words to be idiomatic.
- Removed some `fmt.Errorf` in favor of `errors.New` where formatting wasn't needed to create error