### PR TITLE
journald: use body["MESSAGE"] for entry body

### DIFF
--- a/operator/builtin/input/journald/journald.go
+++ b/operator/builtin/input/journald/journald.go
@@ -222,9 +222,15 @@ func (operator *JournaldInput) parseJournalEntry(line []byte) (*entry.Entry, str
 		return nil, "", errors.New("journald field for cursor is not a string")
 	}
 
-	entry, err := operator.NewEntry(body)
+	entry, err := operator.NewEntry(body["MESSAGE"])
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create entry: %s", err)
+	}
+
+	delete(body, "MESSAGE")
+
+	for k, v := range body {
+		entry.AddAttribute(k, v.(string))
 	}
 
 	entry.Timestamp = time.Unix(0, timestampInt*1000) // in microseconds

--- a/operator/builtin/input/journald/journald_test.go
+++ b/operator/builtin/input/journald/journald_test.go
@@ -72,14 +72,14 @@ func TestInputJournald(t *testing.T) {
 	require.NoError(t, err)
 	defer op.Stop()
 
-	expected := map[string]interface{}{
+	expectedBody := "run-docker-netns-4f76d707d45f.mount: Succeeded."
+	expectedAttributes := map[string]string{
 		"_BOOT_ID":                   "c4fa36de06824d21835c05ff80c54468",
 		"_CAP_EFFECTIVE":             "0",
 		"_TRANSPORT":                 "journal",
 		"_UID":                       "1000",
 		"_EXE":                       "/usr/lib/systemd/systemd",
 		"_AUDIT_LOGINUID":            "1000",
-		"MESSAGE":                    "run-docker-netns-4f76d707d45f.mount: Succeeded.",
 		"_PID":                       "13894",
 		"_CMDLINE":                   "/lib/systemd/systemd --user",
 		"_MACHINE_ID":                "d777d00e7caf45fbadedceba3975520d",
@@ -111,7 +111,8 @@ func TestInputJournald(t *testing.T) {
 
 	select {
 	case e := <-received:
-		require.Equal(t, expected, e.Body)
+		require.Equal(t, expectedAttributes, e.Attributes)
+		require.Equal(t, expectedBody, e.Body)
 	case <-time.After(time.Second):
 		require.FailNow(t, "Timed out waiting for entry to be read")
 	}


### PR DESCRIPTION
related: https://github.com/open-telemetry/oteps/pull/188, https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5846

Using the following configuration, 
```
receivers:
  journald:
    logLevel: debug

exporters:
  loki:
    endpoint: <YOUR ENDPOINT>

service:
  pipelines:
    traces:
    logs:
      receivers: [journald]
      processors: [batch]
      exporters: [loki]
```

you will see the following error because Loki only supports having the body as a string

```
2021-11-06T16:24:00.252-0700	error	exporterhelper/queued_retry.go:183	Exporting failed. The error is not retryable. Dropping data.	{"kind": "exporter", "name": "loki", "error": "Permanent error: failed to transform logs into Loki log streams", "dropped_items": 10}
go.opentelemetry.io/collector/exporter/exporterhelper.(*retrySender).send
	go.opentelemetry.io/collector@v0.38.0/exporter/exporterhelper/queued_retry.go:183
go.opentelemetry.io/collector/exporter/exporterhelper.(*logsExporterWithObservability).send
	go.opentelemetry.io/collector@v0.38.0/exporter/exporterhelper/logs.go:133
go.opentelemetry.io/collector/exporter/exporterhelper.(*queuedRetrySender).start.func1
	go.opentelemetry.io/collector@v0.38.0/exporter/exporterhelper/queued_retry_inmemory.go:105
go.opentelemetry.io/collector/exporter/exporterhelper/internal.consumerFunc.consume
	go.opentelemetry.io/collector@v0.38.0/exporter/exporterhelper/internal/bounded_memory_queue.go:99
go.opentelemetry.io/collector/exporter/exporterhelper/internal.(*boundedMemoryQueue).StartConsumers.func2
	go.opentelemetry.io/collector@v0.38.0/exporter/exporterhelper/internal/bounded_memory_queue.go:78
```

because the journald receiver sends it in the following format
```
InstrumentationLibraryLogs #0
InstrumentationLibrary
LogRecord #0
Timestamp: 2021-11-06 23:35:07.660848 +0000 UTC
Severity:
ShortName:
Body: {
     -> MESSAGE: STRING(bus: 5, device: 9 was not an MTP device)
     -> PRIORITY: STRING(6)
     -> SYSLOG_FACILITY: STRING(1)
     -> SYSLOG_IDENTIFIER: STRING(mtp-probe)
     -> SYSLOG_RAW: STRING(<14>Nov  6 16:35:07 mtp-probe: bus: 5, device: 9 was not an MTP device
)
     -> SYSLOG_TIMESTAMP: STRING(Nov  6 16:35:07 )
     -> _BOOT_ID: STRING(21c95bd00483448d827e6a6ef98de97c)
     -> _CAP_EFFECTIVE: STRING(1f7fdffffff)
     -> _CMDLINE: STRING(/usr/lib/udev/mtp-probe /sys/devices/pci0000:00/0000:00:08.1/0000:0a:00.3/usb5/5-1/5-1.4 5 9)
     -> _COMM: STRING(mtp-probe)
     -> _EXE: STRING(/usr/lib/udev/mtp-probe)
     -> _GID: STRING(0)
     -> _HOSTNAME: STRING(<REDACTED>)
     -> _MACHINE_ID: STRING(<REDACTED>)
     -> _PID: STRING(12954)
     -> _SOURCE_REALTIME_TIMESTAMP: STRING(1636241707660701)
     -> _SYSTEMD_CGROUP: STRING(/system.slice/systemd-udevd.service)
     -> _SYSTEMD_INVOCATION_ID: STRING(0a0cdf1e7f944d00b6475c04ed95c8fd)
     -> _SYSTEMD_SLICE: STRING(system.slice)
     -> _SYSTEMD_UNIT: STRING(systemd-udevd.service)
     -> _TRANSPORT: STRING(syslog)
     -> _UID: STRING(0)
     -> __CURSOR: STRING(s=9a461c87381b4d44a4867d9f1b5aa4c1;i=1818a;b=21c95bd00483448d827e6a6ef98de97c;m=100c8eacd;t=5d02735c07630;x=c701fd6f994b7f13)
     -> __MONOTONIC_TIMESTAMP: STRING(4308134605)
}
```

If I am reading the discussion on https://github.com/open-telemetry/oteps/pull/188 correctly, it seems like the move is to standarize on Body being a string and putting the rest of the fields in the attributes which will solve the Loki exporter errors from above.

Wanted to open this sample PR to see if this is the correct approach / something y'all are interested in doing.