### PR TITLE
Source identifier

### DIFF
--- a/docs/operators/recombine.md
+++ b/docs/operators/recombine.md
@@ -16,7 +16,7 @@ The `recombine` operator combines consecutive logs into single logs based on sim
 | `max_batch_size`     | 1000             | The maximum number of consecutive entries that will be combined into a single entry. |
 | `overwrite_with`     | `oldest`         | Whether to use the fields from the `oldest` or the `newest` entry for all the fields that are not combined. |
 | `force_flush_period` | `5s`             | Flush timeout after which entries will be flushed aborting the wait for their sub parts to be merged with. |
-| `source_identifier`  |                  | The [field](/docs/types/field.md) to separate one source of logs from others when combining them. (i.e., `$attributes["file.path"]`) |
+| `source_identifier`  | `$attibutes["file.path"]` | The [field](/docs/types/field.md) to separate one source of logs from others when combining them. |
 
 Exactly one of `is_first_entry` and `is_last_entry` must be specified.
 

--- a/docs/operators/recombine.md
+++ b/docs/operators/recombine.md
@@ -16,6 +16,7 @@ The `recombine` operator combines consecutive logs into single logs based on sim
 | `max_batch_size`     | 1000             | The maximum number of consecutive entries that will be combined into a single entry. |
 | `overwrite_with`     | `oldest`         | Whether to use the fields from the `oldest` or the `newest` entry for all the fields that are not combined. |
 | `force_flush_period` | `5s`             | Flush timeout after which entries will be flushed aborting the wait for their sub parts to be merged with. |
+| `source_identifier`  |                  | The [field](/docs/types/field.md) to separate one source of logs from others when combining them. (i.e., `$attributes["file.path"]`) |
 
 Exactly one of `is_first_entry` and `is_last_entry` must be specified.
 

--- a/docs/operators/recombine.md
+++ b/docs/operators/recombine.md
@@ -17,6 +17,7 @@ The `recombine` operator combines consecutive logs into single logs based on sim
 | `overwrite_with`     | `oldest`         | Whether to use the fields from the `oldest` or the `newest` entry for all the fields that are not combined. |
 | `force_flush_period` | `5s`             | Flush timeout after which entries will be flushed aborting the wait for their sub parts to be merged with. |
 | `source_identifier`  | `$attibutes["file.path"]` | The [field](/docs/types/field.md) to separate one source of logs from others when combining them. |
+| `max_sources`        | 1000             | The maximum number of unique sources allowed concurrently to be tracked for combining separately. |
 
 Exactly one of `is_first_entry` and `is_last_entry` must be specified.
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 )
 
 require (
-	github.com/benbjohnson/clock v1.1.0 // indirect
+	github.com/benbjohnson/clock v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/evanphx/json-patch v4.9.0+incompatible // indirect
 	github.com/go-logr/logr v0.4.0 // indirect
@@ -34,6 +34,7 @@ require (
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.4.1 // indirect
+	github.com/kr/pretty v0.3.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -77,7 +77,6 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.3.2/go.mod h1:72H
 github.com/aws/aws-sdk-go-v2/service/sso v1.4.2/go.mod h1:NBvT9R1MEF+Ud6ApJKM0G+IkPchKS7p7c2YPKwHmBOk=
 github.com/aws/aws-sdk-go-v2/service/sts v1.7.2/go.mod h1:8EzeIqfWt2wWT4rJVu3f21TfrhJ8AEMzVybRNSb/b4g=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
-github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.2.0 h1:9Re3G2TWxkE06LdMWMpcY6KV81GLXMGiYpPYUPkFAws=
 github.com/benbjohnson/clock v1.2.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -317,7 +316,6 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
@@ -432,6 +430,7 @@ github.com/rivo/tview v0.0.0-20200219210816-cd38d7432498/go.mod h1:6lkG1x+13OShE
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rs/cors v1.8.0/go.mod h1:EBwu+T5AvHOcXwvZIkQFjUN6s8Czyqw12GL/Y0tUyRM=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/operator/builtin/transformer/recombine/recombine.go
+++ b/operator/builtin/transformer/recombine/recombine.go
@@ -156,11 +156,11 @@ func (r *RecombineOperator) flushLoop() {
 			for source, entries := range r.batchMap {
 				lastEntryTs := entries[len(entries)-1].Timestamp
 				timeSinceLastEntry := timeNow.Sub(lastEntryTs)
-				if timeSinceLastEntry > r.forceFlushTimeout {
-					err := r.flushSource(source)
-					if err != nil {
-						r.Errorf("there was error flushing combined logs %s", err)
-					}
+				if timeSinceLastEntry < r.forceFlushTimeout {
+					continue
+				}
+				if err := r.flushSource(source); err != nil {
+					r.Errorf("there was error flushing combined logs %s", err)
 				}
 			}
 

--- a/operator/builtin/transformer/recombine/recombine.go
+++ b/operator/builtin/transformer/recombine/recombine.go
@@ -262,7 +262,7 @@ func (r *RecombineOperator) matchIndicatesLast() bool {
 func (r *RecombineOperator) addToBatch(ctx context.Context, e *entry.Entry, source string) {
 	if _, ok := r.batchMap[source]; !ok {
 		r.batchMap[source] = []*entry.Entry{e}
-		if len(r.batchMap) > r.maxSources {
+		if len(r.batchMap) >= r.maxSources {
 			r.Error("Batched source exceeds max source size. Flushing all batched logs. Consider increasing max_sources parameter")
 			r.flushUncombined(ctx)
 		}

--- a/operator/builtin/transformer/recombine/recombine_test.go
+++ b/operator/builtin/transformer/recombine/recombine_test.go
@@ -221,8 +221,8 @@ func TestRecombineOperator(t *testing.T) {
 			}(),
 			[]*entry.Entry{
 				entryWithBodyAttr(t1, "file1_event1", map[string]string{"file.path": "file1"}),
-				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file1"}),
 				entryWithBodyAttr(t1, "file2_event1", map[string]string{"file.path": "file2"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file1"}),
 				entryWithBodyAttr(t2, "file2_event2", map[string]string{"file.path": "file2"}),
 				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file2"}),
 			},

--- a/operator/builtin/transformer/recombine/recombine_test.go
+++ b/operator/builtin/transformer/recombine/recombine_test.go
@@ -156,18 +156,18 @@ func TestRecombineOperator(t *testing.T) {
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsLastEntry = "$body == 'end'"
 				cfg.OutputIDs = []string{"fake"}
-				cfg.SourceIdentifier = entry.NewAttributeField("file.name")
+				cfg.SourceIdentifier = entry.NewAttributeField("file.path")
 				return cfg
 			}(),
 			[]*entry.Entry{
-				entryWithBodyAttr(t1, "file1", map[string]string{"file.name": "file1"}),
-				entryWithBodyAttr(t1, "file2", map[string]string{"file.name": "file2"}),
-				entryWithBodyAttr(t2, "end", map[string]string{"file.name": "file1"}),
-				entryWithBodyAttr(t2, "end", map[string]string{"file.name": "file2"}),
+				entryWithBodyAttr(t1, "file1", map[string]string{"file.path": "file1"}),
+				entryWithBodyAttr(t1, "file2", map[string]string{"file.path": "file2"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file1"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file2"}),
 			},
 			[]*entry.Entry{
-				entryWithBodyAttr(t1, "file1\nend", map[string]string{"file.name": "file1"}),
-				entryWithBodyAttr(t1, "file2\nend", map[string]string{"file.name": "file2"}),
+				entryWithBodyAttr(t1, "file1\nend", map[string]string{"file.path": "file1"}),
+				entryWithBodyAttr(t1, "file2\nend", map[string]string{"file.path": "file2"}),
 			},
 		},
 	}

--- a/operator/builtin/transformer/recombine/recombine_test.go
+++ b/operator/builtin/transformer/recombine/recombine_test.go
@@ -203,17 +203,10 @@ func TestRecombineOperator(t *testing.T) {
 			[]*entry.Entry{
 				entryWithBodyAttr(t1, "file1", map[string]string{"file.path": "file1"}),
 				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file1"}),
-				entryWithBodyAttr(t1, "file2", map[string]string{"file.path": "file2"}),
-				entryWithBodyAttr(t1, "file3", map[string]string{"file.path": "file3"}),
-				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file2"}),
-				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file3"}),
 			},
 			[]*entry.Entry{
-				entryWithBodyAttr(t1, "file1\nend", map[string]string{"file.path": "file1"}),
-				entryWithBodyAttr(t1, "file2", map[string]string{"file.path": "file2"}),
-				entryWithBodyAttr(t1, "file3", map[string]string{"file.path": "file3"}),
-				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file2"}),
-				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file3"}),
+				entryWithBodyAttr(t1, "file1", map[string]string{"file.path": "file1"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file1"}),
 			},
 		},
 		{

--- a/operator/builtin/transformer/recombine/recombine_test.go
+++ b/operator/builtin/transformer/recombine/recombine_test.go
@@ -150,13 +150,12 @@ func TestRecombineOperator(t *testing.T) {
 			[]*entry.Entry{entryWithBody(t1, "test1test2")},
 		},
 		{
-			"fourEntriesTwoSourceIdentifier",
+			"TestDefaultSourceIdentifier",
 			func() *RecombineOperatorConfig {
 				cfg := NewRecombineOperatorConfig("")
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsLastEntry = "$body == 'end'"
 				cfg.OutputIDs = []string{"fake"}
-				cfg.SourceIdentifier = entry.NewAttributeField("file.path")
 				return cfg
 			}(),
 			[]*entry.Entry{
@@ -168,6 +167,76 @@ func TestRecombineOperator(t *testing.T) {
 			[]*entry.Entry{
 				entryWithBodyAttr(t1, "file1\nend", map[string]string{"file.path": "file1"}),
 				entryWithBodyAttr(t1, "file2\nend", map[string]string{"file.path": "file2"}),
+			},
+		},
+		{
+			"TestCustomSourceIdentifier",
+			func() *RecombineOperatorConfig {
+				cfg := NewRecombineOperatorConfig("")
+				cfg.CombineField = entry.NewBodyField()
+				cfg.IsLastEntry = "$body == 'end'"
+				cfg.OutputIDs = []string{"fake"}
+				cfg.SourceIdentifier = entry.NewAttributeField("custom_source")
+				return cfg
+			}(),
+			[]*entry.Entry{
+				entryWithBodyAttr(t1, "file1", map[string]string{"custom_source": "file1"}),
+				entryWithBodyAttr(t1, "file2", map[string]string{"custom_source": "file2"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"custom_source": "file1"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"custom_source": "file2"}),
+			},
+			[]*entry.Entry{
+				entryWithBodyAttr(t1, "file1\nend", map[string]string{"custom_source": "file1"}),
+				entryWithBodyAttr(t1, "file2\nend", map[string]string{"custom_source": "file2"}),
+			},
+		},
+		{
+			"TestMaxSources",
+			func() *RecombineOperatorConfig {
+				cfg := NewRecombineOperatorConfig("")
+				cfg.CombineField = entry.NewBodyField()
+				cfg.IsLastEntry = "$body == 'end'"
+				cfg.OutputIDs = []string{"fake"}
+				cfg.MaxSources = 1
+				return cfg
+			}(),
+			[]*entry.Entry{
+				entryWithBodyAttr(t1, "file1", map[string]string{"file.path": "file1"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file1"}),
+				entryWithBodyAttr(t1, "file2", map[string]string{"file.path": "file2"}),
+				entryWithBodyAttr(t1, "file3", map[string]string{"file.path": "file3"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file2"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file3"}),
+			},
+			[]*entry.Entry{
+				entryWithBodyAttr(t1, "file1\nend", map[string]string{"file.path": "file1"}),
+				entryWithBodyAttr(t1, "file2", map[string]string{"file.path": "file2"}),
+				entryWithBodyAttr(t1, "file3", map[string]string{"file.path": "file3"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file2"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file3"}),
+			},
+		},
+		{
+			"TestMaxBatchSize",
+			func() *RecombineOperatorConfig {
+				cfg := NewRecombineOperatorConfig("")
+				cfg.CombineField = entry.NewBodyField()
+				cfg.IsLastEntry = "$body == 'end'"
+				cfg.OutputIDs = []string{"fake"}
+				cfg.MaxBatchSize = 2
+				return cfg
+			}(),
+			[]*entry.Entry{
+				entryWithBodyAttr(t1, "file1_event1", map[string]string{"file.path": "file1"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file1"}),
+				entryWithBodyAttr(t1, "file2_event1", map[string]string{"file.path": "file2"}),
+				entryWithBodyAttr(t2, "file2_event2", map[string]string{"file.path": "file2"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file2"}),
+			},
+			[]*entry.Entry{
+				entryWithBodyAttr(t1, "file1_event1\nend", map[string]string{"file.path": "file1"}),
+				entryWithBodyAttr(t1, "file2_event1\nfile2_event2", map[string]string{"file.path": "file2"}),
+				entryWithBodyAttr(t2, "end", map[string]string{"file.path": "file2"}),
 			},
 		},
 	}


### PR DESCRIPTION
fixes #276 
Added sourceIdentifier parameter to prevent logs from multiple files being combined into one event.

Had to update the flush timeout logic to apply the timeout separately for each source. 
