### PR TITLE
Change log level for missing file case

### DIFF
--- a/operator/builtin/input/file/file.go
+++ b/operator/builtin/input/file/file.go
@@ -208,7 +208,7 @@ func (f *InputOperator) makeReaders(filesPaths []string) []*Reader {
 		}
 		file, err := os.Open(path) // #nosec - operator must read in files defined by user
 		if err != nil {
-			f.Errorw("Failed to open file", zap.Error(err))
+			f.Debugf("Failed to open file", zap.Error(err))
 			continue
 		}
 		files = append(files, file)


### PR DESCRIPTION
When a file cannot be opened by the file_input
operator, we currently print an error log. In cases
where the same file is repeatedly unopenable, this will
spam error logs every poll interval. By making this a
debug log, users can still discover the issue if closely
concerned.

Resolves #342 