### PR TITLE
Update attribute names used by file_input, to match semantic conventions

### DIFF
--- a/docs/operators/file_input.md
+++ b/docs/operators/file_input.md
@@ -14,10 +14,10 @@ The `file_input` operator reads logs from files. It will place the lines read in
 | `multiline`                     |                  | A `multiline` configuration block. See below for details. |
 | `force_flush_period`            | `500ms`          | Time since last read of data from file, after which currently buffered log should be send to pipeline. Takes [duration](../types/duration.md) as value. Zero means waiting for new data forever. |
 | `encoding`                      | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options. |
-| `include_file_name`             | `true`           | Whether to add the file name as the attribute `file.name`. |
-| `include_file_path`             | `false`          | Whether to add the file path as the attribute `file.path`. |
-| `include_file_name_resolved`    | `false`          | Whether to add the file name after symlinks resolution as the attribute `file.name.resolved`. |
-| `include_file_path_resolved`    | `false`          | Whether to add the file path after symlinks resolution as the attribute `file.path.resolved`. |
+| `include_file_name`             | `true`           | Whether to add the file name as the attribute `log.file.name`. |
+| `include_file_path`             | `false`          | Whether to add the file path as the attribute `log.file.path`. |
+| `include_file_name_resolved`    | `false`          | Whether to add the file name after symlinks resolution as the attribute `log.file.name_resolved`. |
+| `include_file_path_resolved`    | `false`          | Whether to add the file path after symlinks resolution as the attribute `log.file.path_resolved`. |
 | `start_at`                      | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`. |
 | `fingerprint_size`              | `1kb`            | The number of bytes with which to identify a file. The first bytes in the file are used as the fingerprint. Decreasing this value at any point will cause existing fingerprints to forgotten, meaning that all files will be read from the beginning (one time). |
 | `max_log_size`                  | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |.

--- a/operator/input/file/config.go
+++ b/operator/input/file/config.go
@@ -135,22 +135,22 @@ func (c InputConfig) Build(logger *zap.SugaredLogger) (operator.Operator, error)
 
 	fileNameField := entry.NewNilField()
 	if c.IncludeFileName {
-		fileNameField = entry.NewAttributeField("file.name")
+		fileNameField = entry.NewAttributeField("log.file.name")
 	}
 
 	filePathField := entry.NewNilField()
 	if c.IncludeFilePath {
-		filePathField = entry.NewAttributeField("file.path")
+		filePathField = entry.NewAttributeField("log.file.path")
 	}
 
 	fileNameResolvedField := entry.NewNilField()
 	if c.IncludeFileNameResolved {
-		fileNameResolvedField = entry.NewAttributeField("file.name.resolved")
+		fileNameResolvedField = entry.NewAttributeField("log.file.name_resolved")
 	}
 
 	filePathResolvedField := entry.NewNilField()
 	if c.IncludeFilePathResolved {
-		filePathResolvedField = entry.NewAttributeField("file.path.resolved")
+		filePathResolvedField = entry.NewAttributeField("log.file.path_resolved")
 	}
 
 	return &InputOperator{

--- a/operator/input/file/config_test.go
+++ b/operator/input/file/config_test.go
@@ -541,7 +541,7 @@ func TestBuild(t *testing.T) {
 				require.Equal(t, f.OutputOperators[0], fakeOutput)
 				require.Equal(t, f.finder.Include, []string{"/var/log/testpath.*"})
 				require.Equal(t, f.FilePathField, entry.NewNilField())
-				require.Equal(t, f.FileNameField, entry.NewAttributeField("file.name"))
+				require.Equal(t, f.FileNameField, entry.NewAttributeField("log.file.name"))
 				require.Equal(t, f.PollInterval, 10*time.Millisecond)
 			},
 		},

--- a/operator/input/file/file_test.go
+++ b/operator/input/file/file_test.go
@@ -45,7 +45,7 @@ See this issue for details: https://github.com/census-instrumentation/opencensus
 	operator.Stop()
 }
 
-// AddFields tests that the `file.name` and `file.path` fields are included
+// AddFields tests that the `log.file.name` and `log.file.path` fields are included
 // when IncludeFileName and IncludeFilePath are set to true
 func TestAddFileFields(t *testing.T) {
 	t.Parallel()
@@ -62,11 +62,11 @@ func TestAddFileFields(t *testing.T) {
 	defer operator.Stop()
 
 	e := waitForOne(t, logReceived)
-	require.Equal(t, filepath.Base(temp.Name()), e.Attributes["file.name"])
-	require.Equal(t, temp.Name(), e.Attributes["file.path"])
+	require.Equal(t, filepath.Base(temp.Name()), e.Attributes["log.file.name"])
+	require.Equal(t, temp.Name(), e.Attributes["log.file.path"])
 }
 
-// AddFileResolvedFields tests that the `file.name.resolved` and `file.path.resolved` fields are included
+// AddFileResolvedFields tests that the `log.file.name_resolved` and `log.file.path_resolved` fields are included
 // when IncludeFileNameResolved and IncludeFilePathResolved are set to true
 func TestAddFileResolvedFields(t *testing.T) {
 	t.Parallel()
@@ -102,17 +102,17 @@ func TestAddFileResolvedFields(t *testing.T) {
 	defer operator.Stop()
 
 	e := waitForOne(t, logReceived)
-	require.Equal(t, filepath.Base(symLinkPath), e.Attributes["file.name"])
-	require.Equal(t, symLinkPath, e.Attributes["file.path"])
-	require.Equal(t, filepath.Base(resolved), e.Attributes["file.name.resolved"])
-	require.Equal(t, resolved, e.Attributes["file.path.resolved"])
+	require.Equal(t, filepath.Base(symLinkPath), e.Attributes["log.file.name"])
+	require.Equal(t, symLinkPath, e.Attributes["log.file.path"])
+	require.Equal(t, filepath.Base(resolved), e.Attributes["log.file.name_resolved"])
+	require.Equal(t, resolved, e.Attributes["log.file.path_resolved"])
 
 	// Clean up (linux based host)
 	// Ignore error on windows host (The process cannot access the file because it is being used by another process.)
 	os.RemoveAll(dir)
 }
 
-// AddFileResolvedFields tests that the `file.name.resolved` and `file.path.resolved` fields are included
+// AddFileResolvedFields tests that the `log.file.name_resolved` and `log.file.path_resolved` fields are included
 // when IncludeFileNameResolved and IncludeFilePathResolved are set to true and underlaying symlink change
 // Scenario:
 // monitored file (symlink) -> middleSymlink -> file_1
@@ -163,10 +163,10 @@ func TestAddFileResolvedFieldsWithChangeOfSymlinkTarget(t *testing.T) {
 	defer operator.Stop()
 
 	e := waitForOne(t, logReceived)
-	require.Equal(t, filepath.Base(symLinkPath), e.Attributes["file.name"])
-	require.Equal(t, symLinkPath, e.Attributes["file.path"])
-	require.Equal(t, filepath.Base(resolved1), e.Attributes["file.name.resolved"])
-	require.Equal(t, resolved1, e.Attributes["file.path.resolved"])
+	require.Equal(t, filepath.Base(symLinkPath), e.Attributes["log.file.name"])
+	require.Equal(t, symLinkPath, e.Attributes["log.file.path"])
+	require.Equal(t, filepath.Base(resolved1), e.Attributes["log.file.name_resolved"])
+	require.Equal(t, resolved1, e.Attributes["log.file.path_resolved"])
 
 	// Change middleSymLink to point to file2
 	err = os.Remove(middleSymLinkPath)
@@ -178,10 +178,10 @@ func TestAddFileResolvedFieldsWithChangeOfSymlinkTarget(t *testing.T) {
 	writeString(t, file2, "testlog2\n")
 
 	e = waitForOne(t, logReceived)
-	require.Equal(t, filepath.Base(symLinkPath), e.Attributes["file.name"])
-	require.Equal(t, symLinkPath, e.Attributes["file.path"])
-	require.Equal(t, filepath.Base(resolved2), e.Attributes["file.name.resolved"])
-	require.Equal(t, resolved2, e.Attributes["file.path.resolved"])
+	require.Equal(t, filepath.Base(symLinkPath), e.Attributes["log.file.name"])
+	require.Equal(t, symLinkPath, e.Attributes["log.file.path"])
+	require.Equal(t, filepath.Base(resolved2), e.Attributes["log.file.name_resolved"])
+	require.Equal(t, resolved2, e.Attributes["log.file.path_resolved"])
 
 	// Clean up (linux based host)
 	// Ignore error on windows host (The process cannot access the file because it is being used by another process.)


### PR DESCRIPTION
Resolves #368 

See [semantic conventions for log media](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/semantic_conventions/media.md#log-file).

This is a breaking change.