### PR TITLE
Syslog input as wrapper

### DIFF
--- a/operator/builtin/input/syslog/syslog.go
+++ b/operator/builtin/input/syslog/syslog.go
@@ -41,7 +41,6 @@ type SyslogInputConfig struct {
 }
 
 func (c SyslogInputConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
-
 	inputBase, err := c.InputConfig.Build(context)
 	if err != nil {
 		return nil, err

--- a/operator/builtin/input/syslog/syslog.go
+++ b/operator/builtin/input/syslog/syslog.go
@@ -117,10 +117,6 @@ type SyslogInput struct {
 
 // Start will start listening for log entries over tcp or udp.
 func (t *SyslogInput) Start(p operator.Persister) error {
-	t.parser.SetOutputIDs(t.OutputIDs)
-	if err := t.parser.SetOutputs(t.WriterOperator.OutputOperators); err != nil {
-		return err
-	}
 	if t.tcp != nil {
 		return t.tcp.Start(p)
 	}
@@ -133,4 +129,10 @@ func (t *SyslogInput) Stop() error {
 		return t.tcp.Stop()
 	}
 	return t.udp.Stop()
+}
+
+// SetOutputs will set the outputs of the internal syslog parser.
+func (t *SyslogInput) SetOutputs(operators []operator.Operator) error {
+	t.parser.SetOutputIDs(t.GetOutputIDs())
+	return t.parser.SetOutputs(operators)
 }

--- a/operator/builtin/input/syslog/syslog_test.go
+++ b/operator/builtin/input/syslog/syslog_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
+	"github.com/open-telemetry/opentelemetry-log-collection/operator"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/builtin/input/tcp"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/builtin/input/udp"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/builtin/parser/syslog"
@@ -41,10 +42,10 @@ func TestSyslogInput(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("TCP-%s", tc.Name), func(t *testing.T) {
-			SyslogInputTest(t, NewSyslogInputConfigWithTcp(tc.Config), tc)
+			SyslogInputTest(t, NewSyslogInputConfigWithTcp(&tc.Config.SyslogBaseConfig), tc)
 		})
 		t.Run(fmt.Sprintf("UDP-%s", tc.Name), func(t *testing.T) {
-			SyslogInputTest(t, NewSyslogInputConfigWithUdp(tc.Config), tc)
+			SyslogInputTest(t, NewSyslogInputConfigWithUdp(&tc.Config.SyslogBaseConfig), tc)
 		})
 	}
 }
@@ -94,75 +95,88 @@ func SyslogInputTest(t *testing.T, cfg *SyslogInputConfig, tc syslog.Case) {
 }
 
 func TestSyslogIDs(t *testing.T) {
-	basicConfig := func() *syslog.SyslogParserConfig {
+	basicConfig := func() *syslog.SyslogBaseConfig {
 		cfg := syslog.NewSyslogParserConfig("test_syslog_parser")
-		return cfg
+		cfg.Protocol = "RFC3164"
+		return &cfg.SyslogBaseConfig
 	}
 
-	cases := []struct {
-		Name          string
-		Cfg           *syslog.SyslogParserConfig
-		ExpectedOpIDs []string
-		UDPorTCP      string
-	}{
-		{
-			Name: "default",
-			Cfg: func() *syslog.SyslogParserConfig {
-				sysCfg := basicConfig()
-				sysCfg.Protocol = "RFC3164"
-				return sysCfg
-			}(),
-			UDPorTCP: "UDP",
-			ExpectedOpIDs: []string{
-				"$.test_syslog.test_syslog_parser",
-				"$.fake",
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(fmt.Sprintf("TCP-%s", tc.Name), func(t *testing.T) {
-			cfg := NewSyslogInputConfigWithTcp(tc.Cfg)
-			bc := testutil.NewBuildContext(t)
-			ops, err := cfg.Build(bc)
-			require.NoError(t, err)
-			for i, op := range ops {
-				out := op.GetOutputIDs()
-				require.Equal(t, tc.ExpectedOpIDs[i], out[0])
-			}
-		})
-		t.Run(fmt.Sprintf("UDP-%s", tc.Name), func(t *testing.T) {
-			cfg := NewSyslogInputConfigWithUdp(tc.Cfg)
-			bc := testutil.NewBuildContext(t)
-			ops, err := cfg.Build(bc)
-			require.NoError(t, err)
-			for i, op := range ops {
-				out := op.GetOutputIDs()
-				require.Equal(t, tc.ExpectedOpIDs[i], out[0])
-			}
-		})
-	}
+	t.Run("TCP", func(t *testing.T) {
+		cfg := NewSyslogInputConfigWithTcp(basicConfig())
+		bc := testutil.NewBuildContext(t)
+		ops, err := cfg.Build(bc)
+		require.NoError(t, err)
+		syslogInputOp := ops[0].(*SyslogInput)
+		require.Equal(t, "$.test_syslog_internal_tcp", syslogInputOp.tcp.ID())
+		require.Equal(t, "$.test_syslog_internal_parser", syslogInputOp.parser.ID())
+		require.Equal(t, []string{syslogInputOp.parser.ID()}, syslogInputOp.tcp.GetOutputIDs())
+		require.Equal(t, []string{"$.fake"}, syslogInputOp.parser.GetOutputIDs())
+		require.Equal(t, []string{"$.fake"}, syslogInputOp.GetOutputIDs())
+	})
+	t.Run("UDP", func(t *testing.T) {
+		cfg := NewSyslogInputConfigWithUdp(basicConfig())
+		bc := testutil.NewBuildContext(t)
+		ops, err := cfg.Build(bc)
+		require.NoError(t, err)
+		syslogInputOp := ops[0].(*SyslogInput)
+		require.Equal(t, "$.test_syslog_internal_udp", syslogInputOp.udp.ID())
+		require.Equal(t, "$.test_syslog_internal_parser", syslogInputOp.parser.ID())
+		require.Equal(t, []string{syslogInputOp.parser.ID()}, syslogInputOp.udp.GetOutputIDs())
+		require.Equal(t, []string{"$.fake"}, syslogInputOp.parser.GetOutputIDs())
+		require.Equal(t, []string{"$.fake"}, syslogInputOp.GetOutputIDs())
+	})
 }
 
-func NewSyslogInputConfigWithTcp(syslogCfg *syslog.SyslogParserConfig) *SyslogInputConfig {
+func TestStartConnectsOutputs(t *testing.T) {
+	// Configure the operator without a specified output
 	cfg := NewSyslogInputConfig("test_syslog")
-	cfg.SyslogParserConfig = *syslogCfg
-	cfg.Tcp = tcp.NewTCPInputConfig("test_syslog_tcp")
+	cfg.SyslogBaseConfig = syslog.NewSyslogParserConfig("test_syslog_parser").SyslogBaseConfig
+	cfg.Protocol = "RFC3164"
+	cfg.Tcp = &tcp.NewTCPInputConfig("test_syslog_tcp").TCPBaseConfig
+	cfg.Tcp.ListenAddress = ":14201"
+	bc := testutil.NewBuildContext(t)
+	ops, err := cfg.Build(bc)
+	require.NoError(t, err)
+	syslogInputOp := ops[0].(*SyslogInput)
+	require.Equal(t, []string{}, syslogInputOp.parser.GetOutputIDs())
+	require.Nil(t, syslogInputOp.parser.OutputOperators)
+
+	// Simulate the pipeline assigning a default output ID to the top level operator
+	defaultOutput := testutil.NewMockOperator("$.fake")
+	syslogInputOp.SetOutputIDs([]string{defaultOutput.ID()})
+	require.NoError(t, syslogInputOp.SetOutputs([]operator.Operator{defaultOutput}))
+
+	// Confirm that top level operator has output, but internal parser does not
+	require.Equal(t, []string{"$.fake"}, syslogInputOp.GetOutputIDs())
+	require.Equal(t, []operator.Operator{defaultOutput}, syslogInputOp.OutputOperators)
+	require.Equal(t, []string{}, syslogInputOp.parser.GetOutputIDs())
+	require.Nil(t, syslogInputOp.parser.OutputOperators)
+
+	// Start and confirm internal parser was hooked up to top level output
+	syslogInputOp.Start(testutil.NewMockPersister(""))
+	require.Equal(t, []string{"$.fake"}, syslogInputOp.parser.GetOutputIDs())
+	require.Equal(t, []operator.Operator{defaultOutput}, syslogInputOp.parser.OutputOperators)
+}
+
+func NewSyslogInputConfigWithTcp(syslogCfg *syslog.SyslogBaseConfig) *SyslogInputConfig {
+	cfg := NewSyslogInputConfig("test_syslog")
+	cfg.SyslogBaseConfig = *syslogCfg
+	cfg.Tcp = &tcp.NewTCPInputConfig("test_syslog_tcp").TCPBaseConfig
 	cfg.Tcp.ListenAddress = ":14201"
 	cfg.OutputIDs = []string{"$.fake"}
 	return cfg
 }
 
-func NewSyslogInputConfigWithUdp(syslogCfg *syslog.SyslogParserConfig) *SyslogInputConfig {
+func NewSyslogInputConfigWithUdp(syslogCfg *syslog.SyslogBaseConfig) *SyslogInputConfig {
 	cfg := NewSyslogInputConfig("test_syslog")
-	cfg.SyslogParserConfig = *syslogCfg
-	cfg.Udp = udp.NewUDPInputConfig("test_syslog_udp")
+	cfg.SyslogBaseConfig = *syslogCfg
+	cfg.Udp = &udp.NewUDPInputConfig("test_syslog_udp").UDPBaseConfig
 	cfg.Udp.ListenAddress = ":12032"
 	cfg.OutputIDs = []string{"$.fake"}
 	return cfg
 }
 
-func TestConfigYamlUnmarshal(t *testing.T) {
+func TestConfigYamlUnmarshalUDP(t *testing.T) {
 	base := `type: syslog_input
 protocol: rfc5424
 udp:
@@ -172,18 +186,25 @@ udp:
 	err := yaml.Unmarshal([]byte(base), &cfg)
 	require.NoError(t, err)
 	require.Equal(t, syslog.RFC5424, cfg.Protocol)
+	require.Nil(t, cfg.Tcp)
+	require.NotNil(t, cfg.Udp)
 	require.Equal(t, "localhost:1234", cfg.Udp.ListenAddress)
+}
 
-	base = `type: syslog_input
+func TestConfigYamlUnmarshalTCP(t *testing.T) {
+	base := `type: syslog_input
 protocol: rfc5424
 tcp:
   listen_address: localhost:1234
   tls:
     ca_file: /tmp/test.ca 
 `
-	err = yaml.Unmarshal([]byte(base), &cfg)
+	var cfg SyslogInputConfig
+	err := yaml.Unmarshal([]byte(base), &cfg)
 	require.NoError(t, err)
 	require.Equal(t, syslog.RFC5424, cfg.Protocol)
+	require.Nil(t, cfg.Udp)
+	require.NotNil(t, cfg.Tcp)
 	require.Equal(t, "localhost:1234", cfg.Tcp.ListenAddress)
 	require.Equal(t, "/tmp/test.ca", cfg.Tcp.TLS.CAFile)
 }

--- a/operator/builtin/input/tcp/tcp.go
+++ b/operator/builtin/input/tcp/tcp.go
@@ -50,15 +50,21 @@ func init() {
 func NewTCPInputConfig(operatorID string) *TCPInputConfig {
 	return &TCPInputConfig{
 		InputConfig: helper.NewInputConfig(operatorID, "tcp_input"),
-		Multiline:   helper.NewMultilineConfig(),
-		Encoding:    helper.NewEncodingConfig(),
+		TCPBaseConfig: TCPBaseConfig{
+			Multiline: helper.NewMultilineConfig(),
+			Encoding:  helper.NewEncodingConfig(),
+		},
 	}
 }
 
 // TCPInputConfig is the configuration of a tcp input operator.
 type TCPInputConfig struct {
 	helper.InputConfig `yaml:",inline"`
+	TCPBaseConfig      `yaml:",inline"`
+}
 
+// TCPBaseConfig is the detailed configuration of a tcp input operator.
+type TCPBaseConfig struct {
 	MaxLogSize    helper.ByteSize         `mapstructure:"max_log_size,omitempty"          json:"max_log_size,omitempty"         yaml:"max_log_size,omitempty"`
 	ListenAddress string                  `mapstructure:"listen_address,omitempty"        json:"listen_address,omitempty"       yaml:"listen_address,omitempty"`
 	TLS           *helper.TLSServerConfig `mapstructure:"tls,omitempty"                   json:"tls,omitempty"                  yaml:"tls,omitempty"`

--- a/operator/builtin/input/tcp/tcp_test.go
+++ b/operator/builtin/input/tcp/tcp_test.go
@@ -283,54 +283,68 @@ func TestBuild(t *testing.T) {
 		{
 			"default-auto-address",
 			TCPInputConfig{
-				ListenAddress: ":0",
+				TCPBaseConfig: TCPBaseConfig{
+					ListenAddress: ":0",
+				},
 			},
 			false,
 		},
 		{
 			"default-fixed-address",
 			TCPInputConfig{
-				ListenAddress: "10.0.0.1:0",
+				TCPBaseConfig: TCPBaseConfig{
+					ListenAddress: "10.0.0.1:0",
+				},
 			},
 			false,
 		},
 		{
 			"default-fixed-address-port",
 			TCPInputConfig{
-				ListenAddress: "10.0.0.1:9000",
+				TCPBaseConfig: TCPBaseConfig{
+					ListenAddress: "10.0.0.1:9000",
+				},
 			},
 			false,
 		},
 		{
 			"buffer-size-valid-default",
 			TCPInputConfig{
-				MaxLogSize:    0,
-				ListenAddress: "10.0.0.1:9000",
+				TCPBaseConfig: TCPBaseConfig{
+					MaxLogSize:    0,
+					ListenAddress: "10.0.0.1:9000",
+				},
 			},
 			false,
 		},
 		{
 			"buffer-size-valid-min",
 			TCPInputConfig{
-				MaxLogSize:    65536,
-				ListenAddress: "10.0.0.1:9000",
+				TCPBaseConfig: TCPBaseConfig{
+					MaxLogSize:    65536,
+					ListenAddress: "10.0.0.1:9000",
+				},
 			},
 			false,
 		},
 		{
 			"buffer-size-negative",
 			TCPInputConfig{
-				MaxLogSize:    -1,
-				ListenAddress: "10.0.0.1:9000",
+				TCPBaseConfig: TCPBaseConfig{
+					MaxLogSize:    -1,
+					ListenAddress: "10.0.0.1:9000",
+				},
 			},
 			true,
 		},
 		{
 			"tls-enabled-with-no-such-file-error",
 			TCPInputConfig{
-				MaxLogSize:    65536,
-				ListenAddress: "10.0.0.1:9000",
-				TLS:           createTlsConfig("/tmp/cert/missing", "/tmp/key/missing"),
+				TCPBaseConfig: TCPBaseConfig{
+					MaxLogSize:    65536,
+					ListenAddress: "10.0.0.1:9000",
+					TLS:           createTlsConfig("/tmp/cert/missing", "/tmp/key/missing"),
+				},
 			},
 			true,
 		},

--- a/operator/builtin/input/udp/udp.go
+++ b/operator/builtin/input/udp/udp.go
@@ -42,10 +42,12 @@ func init() {
 func NewUDPInputConfig(operatorID string) *UDPInputConfig {
 	return &UDPInputConfig{
 		InputConfig: helper.NewInputConfig(operatorID, "udp_input"),
-		Encoding:    helper.NewEncodingConfig(),
-		Multiline: helper.MultilineConfig{
-			LineStartPattern: "",
-			LineEndPattern:   ".^", // Use never matching regex to not split data by default
+		UDPBaseConfig: UDPBaseConfig{
+			Encoding: helper.NewEncodingConfig(),
+			Multiline: helper.MultilineConfig{
+				LineStartPattern: "",
+				LineEndPattern:   ".^", // Use never matching regex to not split data by default
+			},
 		},
 	}
 }
@@ -53,7 +55,9 @@ func NewUDPInputConfig(operatorID string) *UDPInputConfig {
 // UDPInputConfig is the configuration of a udp input operator.
 type UDPInputConfig struct {
 	helper.InputConfig `yaml:",inline"`
-
+	UDPBaseConfig      `yaml:",inline"`
+}
+type UDPBaseConfig struct {
 	ListenAddress string                 `mapstructure:"listen_address,omitempty"        json:"listen_address,omitempty"       yaml:"listen_address,omitempty"`
 	AddAttributes bool                   `mapstructure:"add_attributes,omitempty"        json:"add_attributes,omitempty"       yaml:"add_attributes,omitempty"`
 	Encoding      helper.EncodingConfig  `mapstructure:",squash,omitempty"               json:",inline,omitempty"              yaml:",inline,omitempty"`

--- a/operator/builtin/input/udp/udp.go
+++ b/operator/builtin/input/udp/udp.go
@@ -57,6 +57,8 @@ type UDPInputConfig struct {
 	helper.InputConfig `yaml:",inline"`
 	UDPBaseConfig      `yaml:",inline"`
 }
+
+// UDPBaseConfig is the details configuration of a udp input operator.
 type UDPBaseConfig struct {
 	ListenAddress string                 `mapstructure:"listen_address,omitempty"        json:"listen_address,omitempty"       yaml:"listen_address,omitempty"`
 	AddAttributes bool                   `mapstructure:"add_attributes,omitempty"        json:"add_attributes,omitempty"       yaml:"add_attributes,omitempty"`

--- a/operator/builtin/parser/syslog/syslog.go
+++ b/operator/builtin/parser/syslog/syslog.go
@@ -45,7 +45,10 @@ func NewSyslogParserConfig(operatorID string) *SyslogParserConfig {
 // SyslogParserConfig is the configuration of a syslog parser operator.
 type SyslogParserConfig struct {
 	helper.ParserConfig `mapstructure:",squash" yaml:",inline"`
+	SyslogBaseConfig    `mapstructure:",squash" yaml:",inline"`
+}
 
+type SyslogBaseConfig struct {
 	Protocol string `mapstructure:"protocol,omitempty" json:"protocol,omitempty" yaml:"protocol,omitempty"`
 	Location string `mapstructure:"location,omitempty" json:"location,omitempty" yaml:"location,omitempty"`
 }

--- a/operator/builtin/parser/syslog/syslog.go
+++ b/operator/builtin/parser/syslog/syslog.go
@@ -48,6 +48,7 @@ type SyslogParserConfig struct {
 	SyslogBaseConfig    `mapstructure:",squash" yaml:",inline"`
 }
 
+// SyslogBaseConfig is the detailed configuration of a syslog parser.
 type SyslogBaseConfig struct {
 	Protocol string `mapstructure:"protocol,omitempty" json:"protocol,omitempty" yaml:"protocol,omitempty"`
 	Location string `mapstructure:"location,omitempty" json:"location,omitempty" yaml:"location,omitempty"`


### PR DESCRIPTION
The syslog_input operator was previously implemented
as a builder that built two operators. While this is
a perfectly fine solution, it happens to be the only
place in this codebase where multiple operators are
returned from a builder, excepting plugins.

This new implementation builds the same two operators,
but then wraps them together within a single operator.
This will allow for the eventual simplification of
other code, once plugins are also removed from this
codebase.

Related to #375, #380