### PR TITLE
Make operator.Builder.Build return one operator

### DIFF
--- a/operator/builtin/input/file/benchmark_test.go
+++ b/operator/builtin/input/file/benchmark_test.go
@@ -156,9 +156,8 @@ func BenchmarkFileInput(b *testing.B) {
 			}
 			cfg.StartAt = "beginning"
 
-			ops, err := cfg.Build(testutil.NewBuildContext(b))
+			op, err := cfg.Build(testutil.NewBuildContext(b))
 			require.NoError(b, err)
-			op := ops[0]
 
 			fakeOutput := testutil.NewFakeOutput(b)
 			err = op.SetOutputs([]operator.Operator{fakeOutput})

--- a/operator/builtin/input/file/config.go
+++ b/operator/builtin/input/file/config.go
@@ -71,7 +71,7 @@ type InputConfig struct {
 }
 
 // Build will build a file input operator from the supplied configuration
-func (c InputConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c InputConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	inputOperator, err := c.InputConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func (c InputConfig) Build(context operator.BuildContext) ([]operator.Operator, 
 		filePathResolvedField = entry.NewAttributeField("file.path.resolved")
 	}
 
-	op := &InputOperator{
+	return &InputOperator{
 		InputOperator:         inputOperator,
 		finder:                c.Finder,
 		PollInterval:          c.PollInterval.Raw(),
@@ -172,7 +172,5 @@ func (c InputConfig) Build(context operator.BuildContext) ([]operator.Operator, 
 		MaxLogSize:            int(c.MaxLogSize),
 		MaxConcurrentFiles:    c.MaxConcurrentFiles,
 		SeenPaths:             make(map[string]struct{}, 100),
-	}
-
-	return []operator.Operator{op}, nil
+	}, nil
 }

--- a/operator/builtin/input/file/config_test.go
+++ b/operator/builtin/input/file/config_test.go
@@ -655,12 +655,11 @@ func TestBuild(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return
 			}
-			op := ops[0]
 
 			err = op.SetOutputs([]operator.Operator{fakeOutput})
 			require.NoError(t, err)

--- a/operator/builtin/input/file/util_test.go
+++ b/operator/builtin/input/file/util_test.go
@@ -54,9 +54,8 @@ func newTestFileOperator(t *testing.T, cfgMod func(*InputConfig), outMod func(*t
 	if cfgMod != nil {
 		cfgMod(cfg)
 	}
-	ops, err := cfg.Build(testutil.NewBuildContext(t))
+	op, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
-	op := ops[0]
 
 	err = op.SetOutputs([]operator.Operator{fakeOutput})
 	require.NoError(t, err)

--- a/operator/builtin/input/generate/generate.go
+++ b/operator/builtin/input/generate/generate.go
@@ -45,7 +45,7 @@ type GenerateInputConfig struct {
 }
 
 // Build will build a generate input operator.
-func (c *GenerateInputConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c *GenerateInputConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	inputOperator, err := c.InputConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -53,13 +53,12 @@ func (c *GenerateInputConfig) Build(context operator.BuildContext) ([]operator.O
 
 	c.Entry.Body = recursiveMapInterfaceToMapString(c.Entry.Body)
 
-	generateInput := &GenerateInput{
+	return &GenerateInput{
 		InputOperator: inputOperator,
 		entry:         c.Entry,
 		count:         c.Count,
 		static:        c.Static,
-	}
-	return []operator.Operator{generateInput}, nil
+	}, nil
 }
 
 // GenerateInput is an operator that generates log entries.

--- a/operator/builtin/input/generate/generate_test.go
+++ b/operator/builtin/input/generate/generate_test.go
@@ -32,9 +32,8 @@ func TestInputGenerate(t *testing.T) {
 		Body: "test message",
 	}
 
-	ops, err := cfg.Build(testutil.NewBuildContext(t))
+	op, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
-	op := ops[0]
 
 	fake := testutil.NewFakeOutput(t)
 	err = op.SetOutputs([]operator.Operator{fake})

--- a/operator/builtin/input/journald/journald.go
+++ b/operator/builtin/input/journald/journald.go
@@ -60,7 +60,7 @@ type JournaldInputConfig struct {
 }
 
 // Build will build a journald input operator from the supplied configuration
-func (c JournaldInputConfig) Build(buildContext operator.BuildContext) ([]operator.Operator, error) {
+func (c JournaldInputConfig) Build(buildContext operator.BuildContext) (operator.Operator, error) {
 	inputOperator, err := c.InputConfig.Build(buildContext)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func (c JournaldInputConfig) Build(buildContext operator.BuildContext) ([]operat
 		}
 	}
 
-	journaldInput := &JournaldInput{
+	return &JournaldInput{
 		InputOperator: inputOperator,
 		newCmd: func(ctx context.Context, cursor []byte) cmd {
 			if cursor != nil {
@@ -110,8 +110,7 @@ func (c JournaldInputConfig) Build(buildContext operator.BuildContext) ([]operat
 			// journalctl is an executable that is required for this operator to function
 		},
 		json: jsoniter.ConfigFastest,
-	}
-	return []operator.Operator{journaldInput}, nil
+	}, nil
 }
 
 // JournaldInput is an operator that process logs using journald

--- a/operator/builtin/input/journald/journald_test.go
+++ b/operator/builtin/input/journald/journald_test.go
@@ -51,9 +51,8 @@ func TestInputJournald(t *testing.T) {
 	cfg := NewJournaldInputConfig("my_journald_input")
 	cfg.OutputIDs = []string{"output"}
 
-	ops, err := cfg.Build(testutil.NewBuildContext(t))
+	op, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
-	op := ops[0]
 
 	mockOutput := testutil.NewMockOperator("$.output")
 	received := make(chan *entry.Entry)

--- a/operator/builtin/input/k8sevent/k8s_event.go
+++ b/operator/builtin/input/k8sevent/k8s_event.go
@@ -57,7 +57,7 @@ type K8sEventsConfig struct {
 }
 
 // Build will build a k8s_event_input operator from the supplied configuration
-func (c K8sEventsConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c K8sEventsConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	input, err := c.InputConfig.Build(context)
 	if err != nil {
 		return nil, errors.Wrap(err, "build transformer")
@@ -67,14 +67,12 @@ func (c K8sEventsConfig) Build(context operator.BuildContext) ([]operator.Operat
 		return nil, fmt.Errorf("`namespaces` must be specified or `discover_namespaces` enabled")
 	}
 
-	op := &K8sEvents{
+	return &K8sEvents{
 		InputOperator:      input,
 		namespaces:         c.Namespaces,
 		discoverNamespaces: c.DiscoverNamespaces,
 		discoveryInterval:  c.DiscoveryInterval,
-	}
-
-	return []operator.Operator{op}, nil
+	}, nil
 }
 
 // K8sEvents is an operator for generating logs from k8s events

--- a/operator/builtin/input/stanza/stanza.go
+++ b/operator/builtin/input/stanza/stanza.go
@@ -43,7 +43,7 @@ type InputConfig struct {
 }
 
 // Build will build a stanza input operator.
-func (c *InputConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c *InputConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	inputOperator, err := c.InputConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -52,11 +52,10 @@ func (c *InputConfig) Build(context operator.BuildContext) ([]operator.Operator,
 	receiver := make(logger.Receiver, c.BufferSize)
 	context.Logger.AddReceiver(receiver)
 
-	input := &Input{
+	return &Input{
 		InputOperator: inputOperator,
 		receiver:      receiver,
-	}
-	return []operator.Operator{input}, nil
+	}, nil
 }
 
 // Input is an operator that receives internal stanza logs.

--- a/operator/builtin/input/stanza/stanza_test.go
+++ b/operator/builtin/input/stanza/stanza_test.go
@@ -29,9 +29,8 @@ func TestStanzaOperator(t *testing.T) {
 	cfg.OutputIDs = []string{"fake"}
 
 	bc := testutil.NewBuildContext(t)
-	ops, err := cfg.Build(bc)
+	op, err := cfg.Build(bc)
 	require.NoError(t, err)
-	op := ops[0]
 
 	fake := testutil.NewFakeOutput(t)
 	op.SetOutputs([]operator.Operator{fake})

--- a/operator/builtin/input/stdin/stdin.go
+++ b/operator/builtin/input/stdin/stdin.go
@@ -45,17 +45,16 @@ type StdinInputConfig struct {
 }
 
 // Build will build a stdin input operator.
-func (c *StdinInputConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c *StdinInputConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	inputOperator, err := c.InputConfig.Build(context)
 	if err != nil {
 		return nil, err
 	}
 
-	stdinInput := &StdinInput{
+	return &StdinInput{
 		InputOperator: inputOperator,
 		stdin:         os.Stdin,
-	}
-	return []operator.Operator{stdinInput}, nil
+	}, nil
 }
 
 // StdinInput is an operator that reads input from stdin

--- a/operator/builtin/input/stdin/stdin_test.go
+++ b/operator/builtin/input/stdin/stdin_test.go
@@ -32,12 +32,12 @@ func TestStdin(t *testing.T) {
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)
-	op[0].SetOutputs([]operator.Operator{fake})
+	op.SetOutputs([]operator.Operator{fake})
 
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	stdin := op[0].(*StdinInput)
+	stdin := op.(*StdinInput)
 	stdin.stdin = r
 
 	require.NoError(t, stdin.Start(testutil.NewMockPersister("test")))

--- a/operator/builtin/input/syslog/syslog_test.go
+++ b/operator/builtin/input/syslog/syslog_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
+	"github.com/open-telemetry/opentelemetry-log-collection/operator"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/builtin/input/tcp"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/builtin/input/udp"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/builtin/parser/syslog"
@@ -50,11 +51,11 @@ func TestSyslogInput(t *testing.T) {
 }
 
 func SyslogInputTest(t *testing.T, cfg *SyslogInputConfig, tc syslog.Case) {
-	ops, err := cfg.Build(testutil.NewBuildContext(t))
+	op, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)
-	ops = append(ops, fake)
+	ops := []operator.Operator{op, fake}
 	p, err := pipeline.NewDirectedPipeline(ops)
 	require.NoError(t, err)
 
@@ -103,9 +104,9 @@ func TestSyslogIDs(t *testing.T) {
 	t.Run("TCP", func(t *testing.T) {
 		cfg := NewSyslogInputConfigWithTcp(basicConfig())
 		bc := testutil.NewBuildContext(t)
-		ops, err := cfg.Build(bc)
+		op, err := cfg.Build(bc)
 		require.NoError(t, err)
-		syslogInputOp := ops[0].(*SyslogInput)
+		syslogInputOp := op.(*SyslogInput)
 		require.Equal(t, "$.test_syslog_internal_tcp", syslogInputOp.tcp.ID())
 		require.Equal(t, "$.test_syslog_internal_parser", syslogInputOp.parser.ID())
 		require.Equal(t, []string{syslogInputOp.parser.ID()}, syslogInputOp.tcp.GetOutputIDs())
@@ -115,9 +116,9 @@ func TestSyslogIDs(t *testing.T) {
 	t.Run("UDP", func(t *testing.T) {
 		cfg := NewSyslogInputConfigWithUdp(basicConfig())
 		bc := testutil.NewBuildContext(t)
-		ops, err := cfg.Build(bc)
+		op, err := cfg.Build(bc)
 		require.NoError(t, err)
-		syslogInputOp := ops[0].(*SyslogInput)
+		syslogInputOp := op.(*SyslogInput)
 		require.Equal(t, "$.test_syslog_internal_udp", syslogInputOp.udp.ID())
 		require.Equal(t, "$.test_syslog_internal_parser", syslogInputOp.parser.ID())
 		require.Equal(t, []string{syslogInputOp.parser.ID()}, syslogInputOp.udp.GetOutputIDs())

--- a/operator/builtin/input/tcp/tcp.go
+++ b/operator/builtin/input/tcp/tcp.go
@@ -74,7 +74,7 @@ type TCPBaseConfig struct {
 }
 
 // Build will build a tcp input operator.
-func (c TCPInputConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c TCPInputConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	inputOperator, err := c.InputConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -134,7 +134,7 @@ func (c TCPInputConfig) Build(context operator.BuildContext) ([]operator.Operato
 		}
 	}
 
-	return []operator.Operator{tcpInput}, nil
+	return tcpInput, nil
 }
 
 // TCPInput is an operator that listens for log entries over tcp.

--- a/operator/builtin/input/tcp/tcp_test.go
+++ b/operator/builtin/input/tcp/tcp_test.go
@@ -90,9 +90,8 @@ func tcpInputTest(input []byte, expected []string) func(t *testing.T) {
 		cfg := NewTCPInputConfig("test_id")
 		cfg.ListenAddress = ":0"
 
-		ops, err := cfg.Build(testutil.NewBuildContext(t))
+		op, err := cfg.Build(testutil.NewBuildContext(t))
 		require.NoError(t, err)
-		op := ops[0]
 
 		mockOutput := testutil.Operator{}
 		tcpInput := op.(*TCPInput)
@@ -141,9 +140,8 @@ func tcpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 		cfg.ListenAddress = ":0"
 		cfg.AddAttributes = true
 
-		ops, err := cfg.Build(testutil.NewBuildContext(t))
+		op, err := cfg.Build(testutil.NewBuildContext(t))
 		require.NoError(t, err)
-		op := ops[0]
 
 		mockOutput := testutil.Operator{}
 		tcpInput := op.(*TCPInput)
@@ -229,9 +227,8 @@ func tlsTCPInputTest(input []byte, expected []string) func(t *testing.T) {
 			},
 		})
 
-		ops, err := cfg.Build(testutil.NewBuildContext(t))
+		op, err := cfg.Build(testutil.NewBuildContext(t))
 		require.NoError(t, err)
-		op := ops[0]
 
 		mockOutput := testutil.Operator{}
 		tcpInput := op.(*TCPInput)
@@ -401,9 +398,8 @@ func TestFailToBind(t *testing.T) {
 	var startTCP func(port int) (*TCPInput, error) = func(int) (*TCPInput, error) {
 		cfg := NewTCPInputConfig("test_id")
 		cfg.ListenAddress = net.JoinHostPort(ip, strconv.Itoa(port))
-		ops, err := cfg.Build(testutil.NewBuildContext(t))
+		op, err := cfg.Build(testutil.NewBuildContext(t))
 		require.NoError(t, err)
-		op := ops[0]
 		mockOutput := testutil.Operator{}
 		tcpInput := op.(*TCPInput)
 		tcpInput.InputOperator.OutputOperators = []operator.Operator{&mockOutput}
@@ -430,9 +426,8 @@ func BenchmarkTcpInput(b *testing.B) {
 	cfg := NewTCPInputConfig("test_id")
 	cfg.ListenAddress = ":0"
 
-	ops, err := cfg.Build(testutil.NewBuildContext(b))
+	op, err := cfg.Build(testutil.NewBuildContext(b))
 	require.NoError(b, err)
-	op := ops[0]
 
 	fakeOutput := testutil.NewFakeOutput(b)
 	tcpInput := op.(*TCPInput)

--- a/operator/builtin/input/udp/udp.go
+++ b/operator/builtin/input/udp/udp.go
@@ -67,7 +67,7 @@ type UDPBaseConfig struct {
 }
 
 // Build will build a udp input operator.
-func (c UDPInputConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c UDPInputConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	inputOperator, err := c.InputConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -107,7 +107,7 @@ func (c UDPInputConfig) Build(context operator.BuildContext) ([]operator.Operato
 		splitFunc:     splitFunc,
 		resolver:      resolver,
 	}
-	return []operator.Operator{udpInput}, nil
+	return udpInput, nil
 }
 
 // UDPInput is an operator that listens to a socket for log entries.

--- a/operator/builtin/input/udp/udp_test.go
+++ b/operator/builtin/input/udp/udp_test.go
@@ -34,9 +34,8 @@ func udpInputTest(input []byte, expected []string) func(t *testing.T) {
 		cfg := NewUDPInputConfig("test_input")
 		cfg.ListenAddress = ":0"
 
-		ops, err := cfg.Build(testutil.NewBuildContext(t))
+		op, err := cfg.Build(testutil.NewBuildContext(t))
 		require.NoError(t, err)
-		op := ops[0]
 
 		mockOutput := testutil.Operator{}
 		udpInput, ok := op.(*UDPInput)
@@ -87,9 +86,8 @@ func udpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 		cfg.ListenAddress = ":0"
 		cfg.AddAttributes = true
 
-		ops, err := cfg.Build(testutil.NewBuildContext(t))
+		op, err := cfg.Build(testutil.NewBuildContext(t))
 		require.NoError(t, err)
-		op := ops[0]
 
 		mockOutput := testutil.Operator{}
 		udpInput, ok := op.(*UDPInput)
@@ -187,9 +185,8 @@ func TestFailToBind(t *testing.T) {
 		cfg := NewUDPInputConfig("test_input")
 		cfg.ListenAddress = net.JoinHostPort(ip, strconv.Itoa(port))
 
-		ops, err := cfg.Build(testutil.NewBuildContext(t))
+		op, err := cfg.Build(testutil.NewBuildContext(t))
 		require.NoError(t, err)
-		op := ops[0]
 
 		mockOutput := testutil.Operator{}
 		udpInput, ok := op.(*UDPInput)
@@ -221,9 +218,8 @@ func BenchmarkUdpInput(b *testing.B) {
 	cfg := NewUDPInputConfig("test_id")
 	cfg.ListenAddress = ":0"
 
-	ops, err := cfg.Build(testutil.NewBuildContext(b))
+	op, err := cfg.Build(testutil.NewBuildContext(b))
 	require.NoError(b, err)
-	op := ops[0]
 
 	fakeOutput := testutil.NewFakeOutput(b)
 	udpInput := op.(*UDPInput)

--- a/operator/builtin/input/windows/operator.go
+++ b/operator/builtin/input/windows/operator.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package windows
@@ -40,7 +41,7 @@ type EventLogConfig struct {
 }
 
 // Build will build a windows event log operator.
-func (c *EventLogConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c *EventLogConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	inputOperator, err := c.InputConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -58,15 +59,14 @@ func (c *EventLogConfig) Build(context operator.BuildContext) ([]operator.Operat
 		return nil, fmt.Errorf("the `start_at` field must be set to `beginning` or `end`")
 	}
 
-	eventLogInput := &EventLogInput{
+	return &EventLogInput{
 		InputOperator: inputOperator,
 		buffer:        NewBuffer(),
 		channel:       c.Channel,
 		maxReads:      c.MaxReads,
 		startAt:       c.StartAt,
 		pollInterval:  c.PollInterval,
-	}
-	return []operator.Operator{eventLogInput}, nil
+	}, nil
 }
 
 // NewDefaultConfig will return an event log config with default values.

--- a/operator/builtin/output/drop/drop.go
+++ b/operator/builtin/output/drop/drop.go
@@ -39,17 +39,15 @@ type DropOutputConfig struct {
 }
 
 // Build will build a drop output operator.
-func (c DropOutputConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c DropOutputConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	outputOperator, err := c.OutputConfig.Build(context)
 	if err != nil {
 		return nil, err
 	}
 
-	dropOutput := &DropOutput{
+	return &DropOutput{
 		OutputOperator: outputOperator,
-	}
-
-	return []operator.Operator{dropOutput}, nil
+	}, nil
 }
 
 // DropOutput is an operator that consumes and ignores incoming entries.

--- a/operator/builtin/output/drop/drop_test.go
+++ b/operator/builtin/output/drop/drop_test.go
@@ -27,9 +27,8 @@ import (
 func TestBuildValid(t *testing.T) {
 	cfg := NewDropOutputConfig("test")
 	ctx := testutil.NewBuildContext(t)
-	ops, err := cfg.Build(ctx)
+	op, err := cfg.Build(ctx)
 	require.NoError(t, err)
-	op := ops[0]
 	require.IsType(t, &DropOutput{}, op)
 }
 
@@ -45,9 +44,8 @@ func TestBuildIvalid(t *testing.T) {
 func TestProcess(t *testing.T) {
 	cfg := NewDropOutputConfig("test")
 	ctx := testutil.NewBuildContext(t)
-	ops, err := cfg.Build(ctx)
+	op, err := cfg.Build(ctx)
 	require.NoError(t, err)
-	op := ops[0]
 
 	entry := entry.New()
 	result := op.Process(context.Background(), entry)

--- a/operator/builtin/output/file/file.go
+++ b/operator/builtin/output/file/file.go
@@ -47,7 +47,7 @@ type FileOutputConfig struct {
 }
 
 // Build will build a file output operator.
-func (c FileOutputConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c FileOutputConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	outputOperator, err := c.OutputConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -65,13 +65,11 @@ func (c FileOutputConfig) Build(context operator.BuildContext) ([]operator.Opera
 		return nil, fmt.Errorf("must provide a path to output to")
 	}
 
-	fileOutput := &FileOutput{
+	return &FileOutput{
 		OutputOperator: outputOperator,
 		path:           c.Path,
 		tmpl:           tmpl,
-	}
-
-	return []operator.Operator{fileOutput}, nil
+	}, nil
 }
 
 // FileOutput is an operator that writes logs to a file.

--- a/operator/builtin/output/stdout/stdout.go
+++ b/operator/builtin/output/stdout/stdout.go
@@ -46,17 +46,16 @@ type StdoutConfig struct {
 }
 
 // Build will build a stdout operator.
-func (c StdoutConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c StdoutConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	outputOperator, err := c.OutputConfig.Build(context)
 	if err != nil {
 		return nil, err
 	}
 
-	op := &StdoutOperator{
+	return &StdoutOperator{
 		OutputOperator: outputOperator,
 		encoder:        json.NewEncoder(Stdout),
-	}
-	return []operator.Operator{op}, nil
+	}, nil
 }
 
 // StdoutOperator is an operator that logs entries using stdout.

--- a/operator/builtin/output/stdout/stdout_test.go
+++ b/operator/builtin/output/stdout/stdout_test.go
@@ -38,9 +38,8 @@ func TestStdoutOperator(t *testing.T) {
 		},
 	}
 
-	ops, err := cfg.Build(testutil.NewBuildContext(t))
+	op, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
-	op := ops[0]
 
 	var buf bytes.Buffer
 	op.(*StdoutOperator).encoder = json.NewEncoder(&buf)

--- a/operator/builtin/parser/csv/csv.go
+++ b/operator/builtin/parser/csv/csv.go
@@ -48,7 +48,7 @@ type CSVParserConfig struct {
 }
 
 // Build will build a csv parser operator.
-func (c CSVParserConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c CSVParserConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	parserOperator, err := c.ParserConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func (c CSVParserConfig) Build(context operator.BuildContext) ([]operator.Operat
 		headers = strings.Split(c.Header, c.FieldDelimiter)
 	}
 
-	csvParser := &CSVParser{
+	return &CSVParser{
 		ParserOperator:  parserOperator,
 		header:          headers,
 		headerAttribute: c.HeaderAttribute,
@@ -84,9 +84,7 @@ func (c CSVParserConfig) Build(context operator.BuildContext) ([]operator.Operat
 		lazyQuotes:      c.LazyQuotes,
 
 		parse: generateParseFunc(headers, fieldDelimiter, c.LazyQuotes),
-	}
-
-	return []operator.Operator{csvParser}, nil
+	}, nil
 }
 
 // CSVParser is an operator that parses csv in an entry.

--- a/operator/builtin/parser/csv/csv_test.go
+++ b/operator/builtin/parser/csv/csv_test.go
@@ -30,9 +30,8 @@ var testHeader = "name,sev,msg"
 func newTestParser(t *testing.T) *CSVParser {
 	cfg := NewCSVParserConfig("test")
 	cfg.Header = testHeader
-	ops, err := cfg.Build(testutil.NewBuildContext(t))
+	op, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
-	op := ops[0]
 	return op.(*CSVParser)
 }
 
@@ -549,13 +548,12 @@ func TestParserCSV(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			if tc.expectBuildErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			op := ops[0]
 
 			fake := testutil.NewFakeOutput(t)
 			op.SetOutputs([]operator.Operator{fake})
@@ -580,9 +578,8 @@ func TestParserCSVMultipleBodies(t *testing.T) {
 		cfg.OutputIDs = []string{"fake"}
 		cfg.Header = testHeader
 
-		ops, err := cfg.Build(testutil.NewBuildContext(t))
+		op, err := cfg.Build(testutil.NewBuildContext(t))
 		require.NoError(t, err)
-		op := ops[0]
 
 		fake := testutil.NewFakeOutput(t)
 		op.SetOutputs([]operator.Operator{fake})
@@ -606,9 +603,8 @@ func TestParserCSVInvalidJSONInput(t *testing.T) {
 		cfg.OutputIDs = []string{"fake"}
 		cfg.Header = testHeader
 
-		ops, err := cfg.Build(testutil.NewBuildContext(t))
+		op, err := cfg.Build(testutil.NewBuildContext(t))
 		require.NoError(t, err)
-		op := ops[0]
 
 		fake := testutil.NewFakeOutput(t)
 		op.SetOutputs([]operator.Operator{fake})

--- a/operator/builtin/parser/json/json.go
+++ b/operator/builtin/parser/json/json.go
@@ -42,18 +42,16 @@ type JSONParserConfig struct {
 }
 
 // Build will build a JSON parser operator.
-func (c JSONParserConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c JSONParserConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	parserOperator, err := c.ParserConfig.Build(context)
 	if err != nil {
 		return nil, err
 	}
 
-	jsonParser := &JSONParser{
+	return &JSONParser{
 		ParserOperator: parserOperator,
 		json:           jsoniter.ConfigFastest,
-	}
-
-	return []operator.Operator{jsonParser}, nil
+	}, nil
 }
 
 // JSONParser is an operator that parses JSON.

--- a/operator/builtin/parser/json/json_test.go
+++ b/operator/builtin/parser/json/json_test.go
@@ -33,16 +33,14 @@ import (
 
 func newTestParser(t *testing.T) *JSONParser {
 	config := NewJSONParserConfig("test")
-	ops, err := config.Build(testutil.NewBuildContext(t))
-	op := ops[0]
+	op, err := config.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
 	return op.(*JSONParser)
 }
 
 func TestJSONParserConfigBuild(t *testing.T) {
 	config := NewJSONParserConfig("test")
-	ops, err := config.Build(testutil.NewBuildContext(t))
-	op := ops[0]
+	op, err := config.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
 	require.IsType(t, &JSONParser{}, op)
 }

--- a/operator/builtin/parser/regex/regex.go
+++ b/operator/builtin/parser/regex/regex.go
@@ -44,7 +44,7 @@ type RegexParserConfig struct {
 }
 
 // Build will build a regex parser operator.
-func (c RegexParserConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c RegexParserConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	parserOperator, err := c.ParserConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -72,12 +72,10 @@ func (c RegexParserConfig) Build(context operator.BuildContext) ([]operator.Oper
 		)
 	}
 
-	regexParser := &RegexParser{
+	return &RegexParser{
 		ParserOperator: parserOperator,
 		regexp:         r,
-	}
-
-	return []operator.Operator{regexParser}, nil
+	}, nil
 }
 
 // RegexParser is an operator that parses regex in an entry.

--- a/operator/builtin/parser/regex/regex_test.go
+++ b/operator/builtin/parser/regex/regex_test.go
@@ -30,9 +30,8 @@ import (
 func newTestParser(t *testing.T, regex string) *RegexParser {
 	cfg := NewRegexParserConfig("test")
 	cfg.Regex = regex
-	ops, err := cfg.Build(testutil.NewBuildContext(t))
+	op, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
-	op := ops[0]
 	return op.(*RegexParser)
 }
 
@@ -90,9 +89,8 @@ func TestParserRegex(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			require.NoError(t, err)
-			op := ops[0]
 
 			fake := testutil.NewFakeOutput(t)
 			op.SetOutputs([]operator.Operator{fake})

--- a/operator/builtin/parser/severity/severity.go
+++ b/operator/builtin/parser/severity/severity.go
@@ -41,7 +41,7 @@ type SeverityParserConfig struct {
 }
 
 // Build will build a time parser operator.
-func (c SeverityParserConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c SeverityParserConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -52,12 +52,10 @@ func (c SeverityParserConfig) Build(context operator.BuildContext) ([]operator.O
 		return nil, err
 	}
 
-	severityOperator := &SeverityParserOperator{
+	return &SeverityParserOperator{
 		TransformerOperator: transformerOperator,
 		SeverityParser:      severityParser,
-	}
-
-	return []operator.Operator{severityOperator}, nil
+	}, nil
 }
 
 // SeverityParserOperator is an operator that parses time from a field to an entry.

--- a/operator/builtin/parser/severity/severity_test.go
+++ b/operator/builtin/parser/severity/severity_test.go
@@ -236,13 +236,12 @@ func runSeverityParseTest(cfg *SeverityParserConfig, ent *entry.Entry, buildErr 
 	return func(t *testing.T) {
 		buildContext := testutil.NewBuildContext(t)
 
-		ops, err := cfg.Build(buildContext)
+		op, err := cfg.Build(buildContext)
 		if buildErr {
 			require.Error(t, err, "expected error when configuring operator")
 			return
 		}
 		require.NoError(t, err, "unexpected error when configuring operator")
-		op := ops[0]
 
 		mockOutput := &testutil.Operator{}
 		resultChan := make(chan *entry.Entry, 1)

--- a/operator/builtin/parser/syslog/syslog.go
+++ b/operator/builtin/parser/syslog/syslog.go
@@ -55,7 +55,7 @@ type SyslogBaseConfig struct {
 }
 
 // Build will build a JSON parser operator.
-func (c SyslogParserConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c SyslogParserConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	if c.ParserConfig.TimeParser == nil {
 		parseFromField := entry.NewBodyField("timestamp")
 		c.ParserConfig.TimeParser = &helper.TimeParser{
@@ -82,13 +82,11 @@ func (c SyslogParserConfig) Build(context operator.BuildContext) ([]operator.Ope
 		return nil, fmt.Errorf("failed to load location %s: %w", c.Location, err)
 	}
 
-	syslogParser := &SyslogParser{
+	return &SyslogParser{
 		ParserOperator: parserOperator,
 		protocol:       c.Protocol,
 		location:       location,
-	}
-
-	return []operator.Operator{syslogParser}, nil
+	}, nil
 }
 
 func buildMachine(protocol string, location *time.Location) (sl.Machine, error) {

--- a/operator/builtin/parser/syslog/syslog_test.go
+++ b/operator/builtin/parser/syslog/syslog_test.go
@@ -41,8 +41,7 @@ func TestSyslogParser(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			ops, err := tc.Config.Build(testutil.NewBuildContext(t))
-			op := ops[0]
+			op, err := tc.Config.Build(testutil.NewBuildContext(t))
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)

--- a/operator/builtin/parser/time/time.go
+++ b/operator/builtin/parser/time/time.go
@@ -41,7 +41,7 @@ type TimeParserConfig struct {
 }
 
 // Build will build a time parser operator.
-func (c TimeParserConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c TimeParserConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -51,12 +51,10 @@ func (c TimeParserConfig) Build(context operator.BuildContext) ([]operator.Opera
 		return nil, err
 	}
 
-	timeParser := &TimeParserOperator{
+	return &TimeParserOperator{
 		TransformerOperator: transformerOperator,
 		TimeParser:          c.TimeParser,
-	}
-
-	return []operator.Operator{timeParser}, nil
+	}, nil
 }
 
 // TimeParserOperator is an operator that parses time from a field to an entry.

--- a/operator/builtin/parser/time/time_test.go
+++ b/operator/builtin/parser/time/time_test.go
@@ -75,13 +75,13 @@ func TestBuild(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg, err := tc.input()
 			require.NoError(t, err, "expected nil error when running test cases input func")
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			if tc.expectErr {
 				require.Error(t, err, "expected error while building time_parser operator")
 				return
 			}
 			require.NoError(t, err, "did not expect error while building time_parser operator")
-			require.Equal(t, 1, len(ops), "expected Build to return one operator")
+			require.NotNil(t, op, "expected Build to return an operator")
 		})
 	}
 }
@@ -155,13 +155,12 @@ func TestProcess(t *testing.T) {
 				require.NoError(t, err)
 				return
 			}
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			if err != nil {
 				require.NoError(t, err)
 				return
 			}
 
-			op := ops[0]
 			require.True(t, op.CanOutput(), "expected test operator CanOutput to return true")
 
 			err = op.Process(context.Background(), tc.input)
@@ -538,13 +537,12 @@ func runLossyTimeParseTest(_ *testing.T, cfg *TimeParserConfig, ent *entry.Entry
 	return func(t *testing.T) {
 		buildContext := testutil.NewBuildContext(t)
 
-		ops, err := cfg.Build(buildContext)
+		op, err := cfg.Build(buildContext)
 		if buildErr {
 			require.Error(t, err, "expected error when configuring operator")
 			return
 		}
 		require.NoError(t, err)
-		op := ops[0]
 
 		mockOutput := &testutil.Operator{}
 		resultChan := make(chan *entry.Entry, 1)

--- a/operator/builtin/parser/trace/trace.go
+++ b/operator/builtin/parser/trace/trace.go
@@ -41,7 +41,7 @@ type TraceParserConfig struct {
 }
 
 // Build will build a trace parser operator.
-func (c TraceParserConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c TraceParserConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -51,12 +51,10 @@ func (c TraceParserConfig) Build(context operator.BuildContext) ([]operator.Oper
 		return nil, err
 	}
 
-	traceOperator := &TraceParserOperator{
+	return &TraceParserOperator{
 		TransformerOperator: transformerOperator,
 		TraceParser:         c.TraceParser,
-	}
-
-	return []operator.Operator{traceOperator}, nil
+	}, nil
 }
 
 // TraceParserConfig is an operator that parses traces from fields to an entry.

--- a/operator/builtin/parser/trace/trace_test.go
+++ b/operator/builtin/parser/trace/trace_test.go
@@ -100,13 +100,13 @@ func TestBuild(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg, err := tc.input()
 			require.NoError(t, err, "expected nil error when running test cases input func")
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			if tc.expectErr {
 				require.Error(t, err, "expected error while building trace_parser operator")
 				return
 			}
 			require.NoError(t, err, "did not expect error while building trace_parser operator")
-			require.Equal(t, 1, len(ops), "expected Build to return one operator")
+			require.NotNil(t, op, "expected Build to return an operator")
 		})
 	}
 }
@@ -126,11 +126,7 @@ func TestProcess(t *testing.T) {
 			"no-op",
 			func() (operator.Operator, error) {
 				cfg := NewTraceParserConfig("test_id")
-				ops, err := cfg.Build(testutil.NewBuildContext(t))
-				if err != nil {
-					return nil, err
-				}
-				return ops[0], nil
+				return cfg.Build(testutil.NewBuildContext(t))
 			},
 			&entry.Entry{
 				Body: "https://google.com:443/path?user=dev",
@@ -149,11 +145,7 @@ func TestProcess(t *testing.T) {
 				cfg.SpanId.ParseFrom = &spanFrom
 				cfg.TraceId.ParseFrom = &traceFrom
 				cfg.TraceFlags.ParseFrom = &flagsFrom
-				ops, err := cfg.Build(testutil.NewBuildContext(t))
-				if err != nil {
-					return nil, err
-				}
-				return ops[0], nil
+				return cfg.Build(testutil.NewBuildContext(t))
 			},
 			&entry.Entry{
 				Body: map[string]interface{}{
@@ -185,11 +177,7 @@ func TestProcess(t *testing.T) {
 				cfg.TraceId.PreserveTo = &traceTo
 				cfg.TraceFlags.ParseFrom = &flagsFrom
 				cfg.TraceFlags.PreserveTo = &flagsTo
-				ops, err := cfg.Build(testutil.NewBuildContext(t))
-				if err != nil {
-					return nil, err
-				}
-				return ops[0], nil
+				return cfg.Build(testutil.NewBuildContext(t))
 			},
 			&entry.Entry{
 				Body: map[string]interface{}{

--- a/operator/builtin/parser/uri/uri.go
+++ b/operator/builtin/parser/uri/uri.go
@@ -42,17 +42,15 @@ type URIParserConfig struct {
 }
 
 // Build will build a uri parser operator.
-func (c URIParserConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c URIParserConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	parserOperator, err := c.ParserConfig.Build(context)
 	if err != nil {
 		return nil, err
 	}
 
-	uriParser := &URIParser{
+	return &URIParser{
 		ParserOperator: parserOperator,
-	}
-
-	return []operator.Operator{uriParser}, nil
+	}, nil
 }
 
 // URIParser is an operator that parses a uri.

--- a/operator/builtin/parser/uri/uri_test.go
+++ b/operator/builtin/parser/uri/uri_test.go
@@ -30,9 +30,8 @@ import (
 
 func newTestParser(t *testing.T) *URIParser {
 	cfg := NewURIParserConfig("test")
-	ops, err := cfg.Build(testutil.NewBuildContext(t))
+	op, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
-	op := ops[0]
 	return op.(*URIParser)
 }
 
@@ -82,11 +81,7 @@ func TestProcess(t *testing.T) {
 			"default",
 			func() (operator.Operator, error) {
 				cfg := NewURIParserConfig("test_id")
-				ops, err := cfg.Build(testutil.NewBuildContext(t))
-				if err != nil {
-					return nil, err
-				}
-				return ops[0], nil
+				return cfg.Build(testutil.NewBuildContext(t))
 			},
 			&entry.Entry{
 				Body: "https://google.com:443/path?user=dev",
@@ -111,11 +106,7 @@ func TestProcess(t *testing.T) {
 				cfg := NewURIParserConfig("test_id")
 				cfg.ParseFrom = entry.NewBodyField("url")
 				cfg.ParseTo = entry.NewBodyField("url2")
-				ops, err := cfg.Build(testutil.NewBuildContext(t))
-				if err != nil {
-					return nil, err
-				}
-				return ops[0], nil
+				return cfg.Build(testutil.NewBuildContext(t))
 			},
 			&entry.Entry{
 				Body: map[string]interface{}{
@@ -143,11 +134,7 @@ func TestProcess(t *testing.T) {
 			func() (operator.Operator, error) {
 				cfg := NewURIParserConfig("test_id")
 				cfg.ParseFrom = entry.NewBodyField("url")
-				ops, err := cfg.Build(testutil.NewBuildContext(t))
-				if err != nil {
-					return nil, err
-				}
-				return ops[0], nil
+				return cfg.Build(testutil.NewBuildContext(t))
 			},
 			&entry.Entry{
 				Body: map[string]interface{}{
@@ -174,11 +161,7 @@ func TestProcess(t *testing.T) {
 				cfg := NewURIParserConfig("test_id")
 				cfg.ParseFrom = entry.NewBodyField("url")
 				cfg.PreserveTo = &cfg.ParseFrom
-				ops, err := cfg.Build(testutil.NewBuildContext(t))
-				if err != nil {
-					return nil, err
-				}
-				return ops[0], nil
+				return cfg.Build(testutil.NewBuildContext(t))
 			},
 			&entry.Entry{
 				Body: map[string]interface{}{

--- a/operator/builtin/transformer/add/add.go
+++ b/operator/builtin/transformer/add/add.go
@@ -46,7 +46,7 @@ type AddOperatorConfig struct {
 }
 
 // Build will build an add operator from the supplied configuration
-func (c AddOperatorConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c AddOperatorConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func (c AddOperatorConfig) Build(context operator.BuildContext) ([]operator.Oper
 	strVal, ok := c.Value.(string)
 	if !ok || !isExpr(strVal) {
 		addOperator.Value = c.Value
-		return []operator.Operator{addOperator}, nil
+		return addOperator, nil
 	}
 	exprStr := strings.TrimPrefix(strVal, "EXPR(")
 	exprStr = strings.TrimSuffix(exprStr, ")")
@@ -70,7 +70,7 @@ func (c AddOperatorConfig) Build(context operator.BuildContext) ([]operator.Oper
 	}
 
 	addOperator.program = compiled
-	return []operator.Operator{addOperator}, nil
+	return addOperator, nil
 }
 
 // AddOperator is an operator that adds a string value or an expression value

--- a/operator/builtin/transformer/add/add_test.go
+++ b/operator/builtin/transformer/add/add_test.go
@@ -240,9 +240,8 @@ func TestProcessAndBuild(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			require.NoError(t, err)
-			op := ops[0]
 
 			add := op.(*AddOperator)
 			fake := testutil.NewFakeOutput(t)

--- a/operator/builtin/transformer/copy/copy.go
+++ b/operator/builtin/transformer/copy/copy.go
@@ -42,7 +42,7 @@ type CopyOperatorConfig struct {
 }
 
 // Build will build a copy operator from the supplied configuration
-func (c CopyOperatorConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c CopyOperatorConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -56,13 +56,11 @@ func (c CopyOperatorConfig) Build(context operator.BuildContext) ([]operator.Ope
 		return nil, fmt.Errorf("copy: missing to field")
 	}
 
-	copyOp := &CopyOperator{
+	return &CopyOperator{
 		TransformerOperator: transformerOperator,
 		From:                c.From,
 		To:                  c.To,
-	}
-
-	return []operator.Operator{copyOp}, nil
+	}, nil
 }
 
 // CopyOperator copies a value from one field and creates a new field with that value

--- a/operator/builtin/transformer/copy/copy_test.go
+++ b/operator/builtin/transformer/copy/copy_test.go
@@ -246,9 +246,8 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			require.NoError(t, err)
-			op := ops[0]
 
 			copy := op.(*CopyOperator)
 			fake := testutil.NewFakeOutput(t)

--- a/operator/builtin/transformer/filter/filter.go
+++ b/operator/builtin/transformer/filter/filter.go
@@ -53,7 +53,7 @@ type FilterOperatorConfig struct {
 }
 
 // Build will build a filter operator from the supplied configuration
-func (c FilterOperatorConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c FilterOperatorConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	transformer, err := c.TransformerConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -68,13 +68,11 @@ func (c FilterOperatorConfig) Build(context operator.BuildContext) ([]operator.O
 		return nil, fmt.Errorf("drop_ratio must be a number between 0 and 1")
 	}
 
-	filterOperator := &FilterOperator{
+	return &FilterOperator{
 		TransformerOperator: transformer,
 		expression:          compiledExpression,
 		dropCutoff:          big.NewInt(int64(c.DropRatio * 1000)),
-	}
-
-	return []operator.Operator{filterOperator}, nil
+	}, nil
 }
 
 // FilterOperator is an operator that filters entries based on matching expressions

--- a/operator/builtin/transformer/filter/filter_test.go
+++ b/operator/builtin/transformer/filter/filter_test.go
@@ -110,9 +110,8 @@ func TestFilterOperator(t *testing.T) {
 			cfg.Expression = tc.expression
 
 			buildContext := testutil.NewBuildContext(t)
-			ops, err := cfg.Build(buildContext)
+			op, err := cfg.Build(buildContext)
 			require.NoError(t, err)
-			op := ops[0]
 
 			filtered := true
 			mockOutput := testutil.NewMockOperator("output")
@@ -137,9 +136,8 @@ func TestFilterDropRatio(t *testing.T) {
 	cfg.Expression = `$.message == "test_message"`
 	cfg.DropRatio = 0.5
 	buildContext := testutil.NewBuildContext(t)
-	ops, err := cfg.Build(buildContext)
+	op, err := cfg.Build(buildContext)
 	require.NoError(t, err)
-	op := ops[0]
 
 	processedEntries := 0
 	mockOutput := testutil.NewMockOperator("output")

--- a/operator/builtin/transformer/flatten/flaltten.go
+++ b/operator/builtin/transformer/flatten/flaltten.go
@@ -43,7 +43,7 @@ type FlattenOperatorConfig struct {
 }
 
 // Build will build a Flatten operator from the supplied configuration
-func (c FlattenOperatorConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c FlattenOperatorConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -53,12 +53,10 @@ func (c FlattenOperatorConfig) Build(context operator.BuildContext) ([]operator.
 		return nil, fmt.Errorf("flatten: field cannot be a resource or attribute")
 	}
 
-	flattenOp := &FlattenOperator{
+	return &FlattenOperator{
 		TransformerOperator: transformerOperator,
 		Field:               c.Field,
-	}
-
-	return []operator.Operator{flattenOp}, nil
+	}, nil
 }
 
 // FlattenOperator flattens an object in the body field

--- a/operator/builtin/transformer/flatten/flatten_test.go
+++ b/operator/builtin/transformer/flatten/flatten_test.go
@@ -269,14 +269,13 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
 
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			if tc.expectErr && err != nil {
 				require.Error(t, err)
 				t.SkipNow()
 			}
 			require.NoError(t, err)
 
-			op := ops[0]
 			flatten := op.(*FlattenOperator)
 			fake := testutil.NewFakeOutput(t)
 			flatten.SetOutputs([]operator.Operator{fake})

--- a/operator/builtin/transformer/metadata/metadata.go
+++ b/operator/builtin/transformer/metadata/metadata.go
@@ -44,7 +44,7 @@ type MetadataOperatorConfig struct {
 }
 
 // Build will build a metadata operator from the supplied configuration
-func (c MetadataOperatorConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c MetadataOperatorConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(context)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build transformer")
@@ -60,13 +60,11 @@ func (c MetadataOperatorConfig) Build(context operator.BuildContext) ([]operator
 		return nil, errors.Wrap(err, "failed to build identifier")
 	}
 
-	metadataOperator := &MetadataOperator{
+	return &MetadataOperator{
 		TransformerOperator: transformerOperator,
 		Attributer:          attributer,
 		Identifier:          identifier,
-	}
-
-	return []operator.Operator{metadataOperator}, nil
+	}, nil
 }
 
 // MetadataOperator is an operator that can add metadata to incoming entries

--- a/operator/builtin/transformer/metadata/metadata_test.go
+++ b/operator/builtin/transformer/metadata/metadata_test.go
@@ -141,9 +141,8 @@ func TestMetadata(t *testing.T) {
 			cfg := NewMetadataOperatorConfig("test_operator_id")
 			cfg.OutputIDs = []string{"fake"}
 			tc.configMod(cfg)
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			require.NoError(t, err)
-			op := ops[0]
 
 			fake := testutil.NewFakeOutput(t)
 			err = op.SetOutputs([]operator.Operator{fake})

--- a/operator/builtin/transformer/move/move.go
+++ b/operator/builtin/transformer/move/move.go
@@ -42,7 +42,7 @@ type MoveOperatorConfig struct {
 }
 
 // Build will build a Move operator from the supplied configuration
-func (c MoveOperatorConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c MoveOperatorConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -52,13 +52,11 @@ func (c MoveOperatorConfig) Build(context operator.BuildContext) ([]operator.Ope
 		return nil, fmt.Errorf("move: missing to or from field")
 	}
 
-	moveOperator := &MoveOperator{
+	return &MoveOperator{
 		TransformerOperator: transformerOperator,
 		From:                c.From,
 		To:                  c.To,
-	}
-
-	return []operator.Operator{moveOperator}, nil
+	}, nil
 }
 
 // MoveOperator is an operator that moves a field's value to a new field

--- a/operator/builtin/transformer/move/move_test.go
+++ b/operator/builtin/transformer/move/move_test.go
@@ -430,9 +430,8 @@ func TestProcessAndBuild(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			require.NoError(t, err)
-			op := ops[0]
 
 			move := op.(*MoveOperator)
 			fake := testutil.NewFakeOutput(t)

--- a/operator/builtin/transformer/noop/noop.go
+++ b/operator/builtin/transformer/noop/noop.go
@@ -39,17 +39,15 @@ type NoopOperatorConfig struct {
 }
 
 // Build will build a noop operator.
-func (c NoopOperatorConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c NoopOperatorConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(context)
 	if err != nil {
 		return nil, err
 	}
 
-	noopOperator := &NoopOperator{
+	return &NoopOperator{
 		TransformerOperator: transformerOperator,
-	}
-
-	return []operator.Operator{noopOperator}, nil
+	}, nil
 }
 
 // NoopOperator is an operator that performs no operations on an entry.

--- a/operator/builtin/transformer/noop/noop_test.go
+++ b/operator/builtin/transformer/noop/noop_test.go
@@ -27,9 +27,8 @@ import (
 
 func TestBuildValid(t *testing.T) {
 	cfg := NewNoopOperatorConfig("test")
-	ops, err := cfg.Build(testutil.NewBuildContext(t))
+	op, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
-	op := ops[0]
 	require.IsType(t, &NoopOperator{}, op)
 }
 
@@ -45,9 +44,8 @@ func TestBuildIvalid(t *testing.T) {
 func TestProcess(t *testing.T) {
 	cfg := NewNoopOperatorConfig("test")
 	cfg.OutputIDs = []string{"fake"}
-	ops, err := cfg.Build(testutil.NewBuildContext(t))
+	op, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
-	op := ops[0]
 
 	fake := testutil.NewFakeOutput(t)
 	op.SetOutputs([]operator.Operator{fake})

--- a/operator/builtin/transformer/recombine/recombine.go
+++ b/operator/builtin/transformer/recombine/recombine.go
@@ -61,7 +61,7 @@ type RecombineOperatorConfig struct {
 }
 
 // Build creates a new RecombineOperator from a config
-func (c *RecombineOperatorConfig) Build(bc operator.BuildContext) ([]operator.Operator, error) {
+func (c *RecombineOperatorConfig) Build(bc operator.BuildContext) (operator.Operator, error) {
 	transformer, err := c.TransformerConfig.Build(bc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build transformer config: %s", err)
@@ -105,7 +105,7 @@ func (c *RecombineOperatorConfig) Build(bc operator.BuildContext) ([]operator.Op
 		return nil, fmt.Errorf("invalid value '%s' for parameter 'overwrite_with'", c.OverwriteWith)
 	}
 
-	recombine := &RecombineOperator{
+	return &RecombineOperator{
 		TransformerOperator: transformer,
 		matchFirstLine:      matchesFirst,
 		prog:                prog,
@@ -119,9 +119,7 @@ func (c *RecombineOperatorConfig) Build(bc operator.BuildContext) ([]operator.Op
 		ticker:              time.NewTicker(c.ForceFlushTimeout),
 		chClose:             make(chan struct{}),
 		sourceIdentifier:    c.SourceIdentifier,
-	}
-
-	return []operator.Operator{recombine}, nil
+	}, nil
 }
 
 // RecombineOperator is an operator that combines a field from consecutive log entries

--- a/operator/builtin/transformer/recombine/recombine_test.go
+++ b/operator/builtin/transformer/recombine/recombine_test.go
@@ -236,9 +236,9 @@ func TestRecombineOperator(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ops, err := tc.config.Build(testutil.NewBuildContext(t))
+			op, err := tc.config.Build(testutil.NewBuildContext(t))
 			require.NoError(t, err)
-			recombine := ops[0].(*RecombineOperator)
+			recombine := op.(*RecombineOperator)
 
 			fake := testutil.NewFakeOutput(t)
 			err = recombine.SetOutputs([]operator.Operator{fake})
@@ -265,9 +265,9 @@ func TestRecombineOperator(t *testing.T) {
 		cfg.CombineField = entry.NewBodyField()
 		cfg.IsFirstEntry = "false"
 		cfg.OutputIDs = []string{"fake"}
-		ops, err := cfg.Build(testutil.NewBuildContext(t))
+		op, err := cfg.Build(testutil.NewBuildContext(t))
 		require.NoError(t, err)
-		recombine := ops[0].(*RecombineOperator)
+		recombine := op.(*RecombineOperator)
 
 		fake := testutil.NewFakeOutput(t)
 		err = recombine.SetOutputs([]operator.Operator{fake})
@@ -300,9 +300,9 @@ func BenchmarkRecombine(b *testing.B) {
 	cfg.CombineField = entry.NewBodyField()
 	cfg.IsFirstEntry = "false"
 	cfg.OutputIDs = []string{"fake"}
-	ops, err := cfg.Build(testutil.NewBuildContext(b))
+	op, err := cfg.Build(testutil.NewBuildContext(b))
 	require.NoError(b, err)
-	recombine := ops[0].(*RecombineOperator)
+	recombine := op.(*RecombineOperator)
 
 	fake := testutil.NewFakeOutput(b)
 	require.NoError(b, recombine.SetOutputs([]operator.Operator{fake}))
@@ -338,9 +338,9 @@ func TestTimeout(t *testing.T) {
 	cfg.IsFirstEntry = "false"
 	cfg.OutputIDs = []string{"fake"}
 	cfg.ForceFlushTimeout = 100 * time.Millisecond
-	ops, err := cfg.Build(testutil.NewBuildContext(t))
+	op, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
-	recombine := ops[0].(*RecombineOperator)
+	recombine := op.(*RecombineOperator)
 
 	fake := testutil.NewFakeOutput(t)
 	require.NoError(t, recombine.SetOutputs([]operator.Operator{fake}))

--- a/operator/builtin/transformer/remove/remove.go
+++ b/operator/builtin/transformer/remove/remove.go
@@ -42,7 +42,7 @@ type RemoveOperatorConfig struct {
 }
 
 // Build will build a Remove operator from the supplied configuration
-func (c RemoveOperatorConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c RemoveOperatorConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -52,12 +52,10 @@ func (c RemoveOperatorConfig) Build(context operator.BuildContext) ([]operator.O
 		return nil, fmt.Errorf("remove: field is empty")
 	}
 
-	removeOperator := &RemoveOperator{
+	return &RemoveOperator{
 		TransformerOperator: transformerOperator,
 		Field:               c.Field,
-	}
-
-	return []operator.Operator{removeOperator}, nil
+	}, nil
 }
 
 // RemoveOperator is an operator that deletes a field

--- a/operator/builtin/transformer/remove/remove_test.go
+++ b/operator/builtin/transformer/remove/remove_test.go
@@ -207,9 +207,8 @@ func TestProcessAndBuild(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			require.NoError(t, err)
-			op := ops[0]
 
 			remove := op.(*RemoveOperator)
 			fake := testutil.NewFakeOutput(t)

--- a/operator/builtin/transformer/restructure/restructure.go
+++ b/operator/builtin/transformer/restructure/restructure.go
@@ -47,18 +47,16 @@ type RestructureOperatorConfig struct {
 }
 
 // Build will build a restructure operator from the supplied configuration
-func (c RestructureOperatorConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c RestructureOperatorConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(context)
 	if err != nil {
 		return nil, err
 	}
 
-	restructureOperator := &RestructureOperator{
+	return &RestructureOperator{
 		TransformerOperator: transformerOperator,
 		ops:                 c.Ops,
-	}
-
-	return []operator.Operator{restructureOperator}, nil
+	}, nil
 }
 
 // RestructureOperator is an operator that can restructure incoming entries using operations

--- a/operator/builtin/transformer/restructure/restructure_test.go
+++ b/operator/builtin/transformer/restructure/restructure_test.go
@@ -199,9 +199,8 @@ func TestRestructureOperator(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := NewRestructureOperatorConfig("test")
 			cfg.OutputIDs = []string{"fake"}
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			require.NoError(t, err)
-			op := ops[0]
 
 			restructure := op.(*RestructureOperator)
 			fake := testutil.NewFakeOutput(t)

--- a/operator/builtin/transformer/retain/retain.go
+++ b/operator/builtin/transformer/retain/retain.go
@@ -42,7 +42,7 @@ type RetainOperatorConfig struct {
 }
 
 // Build will build a retain operator from the supplied configuration
-func (c RetainOperatorConfig) Build(context operator.BuildContext) ([]operator.Operator, error) {
+func (c RetainOperatorConfig) Build(context operator.BuildContext) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(context)
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func (c RetainOperatorConfig) Build(context operator.BuildContext) ([]operator.O
 		}
 		retainOp.AllBodyFields = true
 	}
-	return []operator.Operator{retainOp}, nil
+	return retainOp, nil
 }
 
 // RetainOperator keeps the given fields and deletes the rest.

--- a/operator/builtin/transformer/retain/retain_test.go
+++ b/operator/builtin/transformer/retain/retain_test.go
@@ -317,9 +317,8 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			ops, err := cfg.Build(testutil.NewBuildContext(t))
+			op, err := cfg.Build(testutil.NewBuildContext(t))
 			require.NoError(t, err)
-			op := ops[0]
 
 			retain := op.(*RetainOperator)
 			fake := testutil.NewFakeOutput(t)

--- a/operator/builtin/transformer/router/router.go
+++ b/operator/builtin/transformer/router/router.go
@@ -53,7 +53,7 @@ type RouterOperatorRouteConfig struct {
 }
 
 // Build will build a router operator from the supplied configuration
-func (c RouterOperatorConfig) Build(bc operator.BuildContext) ([]operator.Operator, error) {
+func (c RouterOperatorConfig) Build(bc operator.BuildContext) (operator.Operator, error) {
 	basicOperator, err := c.BasicConfig.Build(bc)
 	if err != nil {
 		return nil, err
@@ -87,16 +87,11 @@ func (c RouterOperatorConfig) Build(bc operator.BuildContext) ([]operator.Operat
 		routes = append(routes, &route)
 	}
 
-	routerOperator := &RouterOperator{
+	return &RouterOperator{
 		BasicOperator: basicOperator,
 		routes:        routes,
-	}
-
-	return []operator.Operator{routerOperator}, nil
+	}, nil
 }
-
-// BuildsMultipleOps returns false
-func (c RouterOperatorConfig) BuildsMultipleOps() bool { return false }
 
 // RouterOperator is an operator that routes entries based on matching expressions
 type RouterOperator struct {

--- a/operator/builtin/transformer/router/router_test.go
+++ b/operator/builtin/transformer/router/router_test.go
@@ -197,9 +197,8 @@ func TestRouterOperator(t *testing.T) {
 			cfg.Default = tc.defaultOutput
 
 			buildContext := testutil.NewBuildContext(t)
-			ops, err := cfg.Build(buildContext)
+			op, err := cfg.Build(buildContext)
 			require.NoError(t, err)
-			op := ops[0]
 
 			results := map[string]int{}
 			var attributes map[string]string

--- a/operator/config.go
+++ b/operator/config.go
@@ -30,9 +30,8 @@ type Config struct {
 type Builder interface {
 	ID() string
 	Type() string
-	Build(BuildContext) ([]Operator, error)
+	Build(BuildContext) (Operator, error)
 	SetID(string)
-	BuildsMultipleOps() bool
 }
 
 // UnmarshalJSON will unmarshal a config from JSON.

--- a/operator/config_test.go
+++ b/operator/config_test.go
@@ -28,11 +28,10 @@ type FakeBuilder struct {
 	Array        []string `json:"array" yaml:"array"`
 }
 
-func (f *FakeBuilder) Build(context BuildContext) ([]Operator, error) { return nil, nil }
-func (f *FakeBuilder) ID() string                                     { return "operator" }
-func (f *FakeBuilder) Type() string                                   { return "operator" }
-func (f *FakeBuilder) SetID(s string)                                 {}
-func (f *FakeBuilder) BuildsMultipleOps() bool                        { return false }
+func (f *FakeBuilder) Build(context BuildContext) (Operator, error) { return nil, nil }
+func (f *FakeBuilder) ID() string                                   { return "operator" }
+func (f *FakeBuilder) Type() string                                 { return "operator" }
+func (f *FakeBuilder) SetID(s string)                               {}
 
 func TestUnmarshalJSONErrors(t *testing.T) {
 	t.Cleanup(func() {

--- a/operator/helper/output.go
+++ b/operator/helper/output.go
@@ -45,9 +45,6 @@ func (c OutputConfig) Build(context operator.BuildContext) (OutputOperator, erro
 	return outputOperator, nil
 }
 
-// BuildsMultipleOps Returns false
-func (c OutputConfig) BuildsMultipleOps() bool { return false }
-
 // OutputOperator provides a basic implementation of an output operator.
 type OutputOperator struct {
 	BasicOperator

--- a/operator/helper/writer.go
+++ b/operator/helper/writer.go
@@ -53,11 +53,6 @@ func (c WriterConfig) Build(bc operator.BuildContext) (WriterOperator, error) {
 	return writer, nil
 }
 
-// BuildsMultipleOps Returns false as a base line
-func (c WriterConfig) BuildsMultipleOps() bool {
-	return false
-}
-
 // WriterOperator is an operator that can write to other operators.
 type WriterOperator struct {
 	BasicOperator

--- a/testutil/operator_builder.go
+++ b/testutil/operator_builder.go
@@ -13,15 +13,15 @@ type OperatorBuilder struct {
 }
 
 // Build provides a mock function with given fields: _a0
-func (_m *OperatorBuilder) Build(_a0 operator.BuildContext) ([]operator.Operator, error) {
+func (_m *OperatorBuilder) Build(_a0 operator.BuildContext) (operator.Operator, error) {
 	ret := _m.Called(_a0)
 
-	var r0 []operator.Operator
-	if rf, ok := ret.Get(0).(func(operator.BuildContext) []operator.Operator); ok {
+	var r0 operator.Operator
+	if rf, ok := ret.Get(0).(func(operator.BuildContext) operator.Operator); ok {
 		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]operator.Operator)
+			r0 = ret.Get(0).(operator.Operator)
 		}
 	}
 
@@ -33,20 +33,6 @@ func (_m *OperatorBuilder) Build(_a0 operator.BuildContext) ([]operator.Operator
 	}
 
 	return r0, r1
-}
-
-// BuildsMultipleOps provides a mock function with given fields:
-func (_m *OperatorBuilder) BuildsMultipleOps() bool {
-	ret := _m.Called()
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
 }
 
 // ID provides a mock function with given fields:
@@ -64,17 +50,8 @@ func (_m *OperatorBuilder) ID() string {
 }
 
 // SetID provides a mock function with given fields: _a0
-func (_m *OperatorBuilder) SetID(_a0 string) error {
-	ret := _m.Called(_a0)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(_a0)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
+func (_m *OperatorBuilder) SetID(_a0 string) {
+	_m.Called(_a0)
 }
 
 // Type provides a mock function with given fields:


### PR DESCRIPTION
The `operator.Builder.Build` function previously required support
for building multiple operators. This was necessary for plugins
and convenient in one other case, but generally just complicated the 
codebase, as many callers had to drill work with a slice even when 
knowing that there would only be one operator in it.

Resolves #380