### PR TITLE
Remove notion of operator namespaces

### DIFF
--- a/agent/builder_test.go
+++ b/agent/builder_test.go
@@ -70,22 +70,22 @@ func TestBuildAgentDefaultOperator(t *testing.T) {
 
 	for _, op := range ops {
 		switch op.ID() {
-		case "$.noop":
+		case "noop":
 			require.Equal(t, 1, len(op.GetOutputIDs()))
-			require.Equal(t, "$.noop1", op.GetOutputIDs()[0])
-			exists["$.noop"] = true
-		case "$.noop1":
+			require.Equal(t, "noop1", op.GetOutputIDs()[0])
+			exists["noop"] = true
+		case "noop1":
 			require.Equal(t, 1, len(op.GetOutputIDs()))
-			require.Equal(t, "$.fake", op.GetOutputIDs()[0])
-			exists["$.noop1"] = true
-		case "$.fake":
+			require.Equal(t, "fake", op.GetOutputIDs()[0])
+			exists["noop1"] = true
+		case "fake":
 			require.Equal(t, 0, len(op.GetOutputIDs()))
-			exists["$.fake"] = true
+			exists["fake"] = true
 		}
 	}
-	require.True(t, exists["$.noop"])
-	require.True(t, exists["$.noop1"])
-	require.True(t, exists["$.fake"])
+	require.True(t, exists["noop"])
+	require.True(t, exists["noop1"])
+	require.True(t, exists["fake"])
 }
 
 func TestBuildAgentFailureNoConfigOrGlobs(t *testing.T) {

--- a/operator/build_context.go
+++ b/operator/build_context.go
@@ -15,34 +15,13 @@
 package operator
 
 import (
-	"fmt"
-	"strings"
-
 	"go.uber.org/zap"
 )
 
 // BuildContext supplies contextual resources when building an operator.
 type BuildContext struct {
-	Parameters       map[string]interface{}
 	Logger           *zap.SugaredLogger
-	Namespace        string
 	DefaultOutputIDs []string
-}
-
-// PrependNamespace adds the current namespace of the build context to the
-// front of the given ID if that ID is not already namespaced up to the root level
-func (bc BuildContext) PrependNamespace(id string) string {
-	if strings.HasPrefix(id, "$.") {
-		return id
-	}
-	return fmt.Sprintf("%s.%s", bc.Namespace, id)
-}
-
-// WithSubNamespace creates a new build context with a more specific namespace
-func (bc BuildContext) WithSubNamespace(namespace string) BuildContext {
-	newBuildContext := bc.Copy()
-	newBuildContext.Namespace = bc.PrependNamespace(namespace)
-	return newBuildContext
 }
 
 // WithDefaultOutputIDs sets the default output IDs for the current context or
@@ -56,20 +35,15 @@ func (bc BuildContext) WithDefaultOutputIDs(ids []string) BuildContext {
 // Copy creates a copy of the build context
 func (bc BuildContext) Copy() BuildContext {
 	return BuildContext{
-		Parameters:       bc.Parameters,
 		Logger:           bc.Logger,
-		Namespace:        bc.Namespace,
 		DefaultOutputIDs: bc.DefaultOutputIDs,
 	}
 }
 
-// NewBuildContext creates a new build context with the given database, logger, and the
-// default namespace
+// NewBuildContext creates a new build context with the given logger
 func NewBuildContext(lg *zap.SugaredLogger) BuildContext {
 	return BuildContext{
-		Parameters:       nil,
 		Logger:           lg,
-		Namespace:        "$",
 		DefaultOutputIDs: []string{},
 	}
 }

--- a/operator/build_context_test.go
+++ b/operator/build_context_test.go
@@ -21,31 +21,6 @@ import (
 )
 
 func TestBuildContext(t *testing.T) {
-	t.Run("PrependNamespace", func(t *testing.T) {
-		bc := BuildContext{
-			Namespace: "$.test",
-		}
-
-		t.Run("Standard", func(t *testing.T) {
-			id := bc.PrependNamespace("testid")
-			require.Equal(t, "$.test.testid", id)
-		})
-
-		t.Run("AlreadyPrefixed", func(t *testing.T) {
-			id := bc.PrependNamespace("$.myns.testid")
-			require.Equal(t, "$.myns.testid", id)
-		})
-	})
-
-	t.Run("WithSubNamespace", func(t *testing.T) {
-		bc := BuildContext{
-			Namespace: "$.ns",
-		}
-		bc2 := bc.WithSubNamespace("subns")
-		require.Equal(t, "$.ns.subns", bc2.Namespace)
-		require.Equal(t, "$.ns", bc.Namespace)
-	})
-
 	t.Run("WithDefaultOutputIDs", func(t *testing.T) {
 		bc := BuildContext{
 			DefaultOutputIDs: []string{"orig"},

--- a/operator/builtin/input/file/config_test.go
+++ b/operator/builtin/input/file/config_test.go
@@ -516,7 +516,7 @@ func TestUnmarshal(t *testing.T) {
 
 func TestBuild(t *testing.T) {
 	t.Parallel()
-	fakeOutput := testutil.NewMockOperator("$.fake")
+	fakeOutput := testutil.NewMockOperator("fake")
 
 	basicConfig := func() *InputConfig {
 		cfg := NewInputConfig("testfile")

--- a/operator/builtin/input/journald/journald_test.go
+++ b/operator/builtin/input/journald/journald_test.go
@@ -54,7 +54,7 @@ func TestInputJournald(t *testing.T) {
 	op, err := cfg.Build(testutil.NewBuildContext(t))
 	require.NoError(t, err)
 
-	mockOutput := testutil.NewMockOperator("$.output")
+	mockOutput := testutil.NewMockOperator("output")
 	received := make(chan *entry.Entry)
 	mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		received <- args.Get(1).(*entry.Entry)

--- a/operator/builtin/input/syslog/syslog_test.go
+++ b/operator/builtin/input/syslog/syslog_test.go
@@ -107,11 +107,11 @@ func TestSyslogIDs(t *testing.T) {
 		op, err := cfg.Build(bc)
 		require.NoError(t, err)
 		syslogInputOp := op.(*SyslogInput)
-		require.Equal(t, "$.test_syslog_internal_tcp", syslogInputOp.tcp.ID())
-		require.Equal(t, "$.test_syslog_internal_parser", syslogInputOp.parser.ID())
+		require.Equal(t, "test_syslog_internal_tcp", syslogInputOp.tcp.ID())
+		require.Equal(t, "test_syslog_internal_parser", syslogInputOp.parser.ID())
 		require.Equal(t, []string{syslogInputOp.parser.ID()}, syslogInputOp.tcp.GetOutputIDs())
-		require.Equal(t, []string{"$.fake"}, syslogInputOp.parser.GetOutputIDs())
-		require.Equal(t, []string{"$.fake"}, syslogInputOp.GetOutputIDs())
+		require.Equal(t, []string{"fake"}, syslogInputOp.parser.GetOutputIDs())
+		require.Equal(t, []string{"fake"}, syslogInputOp.GetOutputIDs())
 	})
 	t.Run("UDP", func(t *testing.T) {
 		cfg := NewSyslogInputConfigWithUdp(basicConfig())
@@ -119,11 +119,11 @@ func TestSyslogIDs(t *testing.T) {
 		op, err := cfg.Build(bc)
 		require.NoError(t, err)
 		syslogInputOp := op.(*SyslogInput)
-		require.Equal(t, "$.test_syslog_internal_udp", syslogInputOp.udp.ID())
-		require.Equal(t, "$.test_syslog_internal_parser", syslogInputOp.parser.ID())
+		require.Equal(t, "test_syslog_internal_udp", syslogInputOp.udp.ID())
+		require.Equal(t, "test_syslog_internal_parser", syslogInputOp.parser.ID())
 		require.Equal(t, []string{syslogInputOp.parser.ID()}, syslogInputOp.udp.GetOutputIDs())
-		require.Equal(t, []string{"$.fake"}, syslogInputOp.parser.GetOutputIDs())
-		require.Equal(t, []string{"$.fake"}, syslogInputOp.GetOutputIDs())
+		require.Equal(t, []string{"fake"}, syslogInputOp.parser.GetOutputIDs())
+		require.Equal(t, []string{"fake"}, syslogInputOp.GetOutputIDs())
 	})
 }
 
@@ -132,7 +132,7 @@ func NewSyslogInputConfigWithTcp(syslogCfg *syslog.SyslogBaseConfig) *SyslogInpu
 	cfg.SyslogBaseConfig = *syslogCfg
 	cfg.Tcp = &tcp.NewTCPInputConfig("test_syslog_tcp").TCPBaseConfig
 	cfg.Tcp.ListenAddress = ":14201"
-	cfg.OutputIDs = []string{"$.fake"}
+	cfg.OutputIDs = []string{"fake"}
 	return cfg
 }
 
@@ -141,7 +141,7 @@ func NewSyslogInputConfigWithUdp(syslogCfg *syslog.SyslogBaseConfig) *SyslogInpu
 	cfg.SyslogBaseConfig = *syslogCfg
 	cfg.Udp = &udp.NewUDPInputConfig("test_syslog_udp").UDPBaseConfig
 	cfg.Udp.ListenAddress = ":12032"
-	cfg.OutputIDs = []string{"$.fake"}
+	cfg.OutputIDs = []string{"fake"}
 	return cfg
 }
 

--- a/operator/builtin/transformer/router/router.go
+++ b/operator/builtin/transformer/router/router.go
@@ -82,7 +82,7 @@ func (c RouterOperatorConfig) Build(bc operator.BuildContext) (operator.Operator
 		route := RouterOperatorRoute{
 			Attributer: attributer,
 			Expression: compiled,
-			OutputIDs:  routeConfig.OutputIDs.WithNamespace(bc),
+			OutputIDs:  routeConfig.OutputIDs,
 		}
 		routes = append(routes, &route)
 	}

--- a/operator/builtin/transformer/router/router_test.go
+++ b/operator/builtin/transformer/router/router_test.go
@@ -203,7 +203,7 @@ func TestRouterOperator(t *testing.T) {
 			results := map[string]int{}
 			var attributes map[string]string
 
-			mock1 := testutil.NewMockOperator("$.output1")
+			mock1 := testutil.NewMockOperator("output1")
 			mock1.On("Process", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 				results["output1"]++
 				if entry, ok := args[1].(*entry.Entry); ok {
@@ -211,7 +211,7 @@ func TestRouterOperator(t *testing.T) {
 				}
 			})
 
-			mock2 := testutil.NewMockOperator("$.output2")
+			mock2 := testutil.NewMockOperator("output2")
 			mock2.On("Process", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 				results["output2"]++
 				if entry, ok := args[1].(*entry.Entry); ok {

--- a/operator/helper/operator.go
+++ b/operator/helper/operator.go
@@ -72,11 +72,10 @@ func (c BasicConfig) Build(context operator.BuildContext) (BasicOperator, error)
 		)
 	}
 
-	namespacedID := context.PrependNamespace(c.ID())
 	operator := BasicOperator{
-		OperatorID:    namespacedID,
+		OperatorID:    c.ID(),
 		OperatorType:  c.Type(),
-		SugaredLogger: context.Logger.With("operator_id", namespacedID, "operator_type", c.Type()),
+		SugaredLogger: context.Logger.With("operator_id", c.ID(), "operator_type", c.Type()),
 	}
 
 	return operator, nil

--- a/operator/helper/operator_test.go
+++ b/operator/helper/operator_test.go
@@ -78,7 +78,7 @@ func TestBasicConfigBuildValid(t *testing.T) {
 	context := testutil.NewBuildContext(t)
 	operator, err := config.Build(context)
 	require.NoError(t, err)
-	require.Equal(t, "$.test-id", operator.OperatorID)
+	require.Equal(t, "test-id", operator.OperatorID)
 	require.Equal(t, "test-type", operator.OperatorType)
 }
 

--- a/operator/helper/writer.go
+++ b/operator/helper/writer.go
@@ -43,14 +43,10 @@ func (c WriterConfig) Build(bc operator.BuildContext) (WriterOperator, error) {
 		return WriterOperator{}, err
 	}
 
-	// Namespace all the output IDs
-	namespacedIDs := c.OutputIDs.WithNamespace(bc)
-
-	writer := WriterOperator{
-		OutputIDs:     namespacedIDs,
+	return WriterOperator{
+		OutputIDs:     c.OutputIDs,
 		BasicOperator: basicOperator,
-	}
-	return writer, nil
+	}, nil
 }
 
 // WriterOperator is an operator that can write to other operators.
@@ -124,14 +120,6 @@ func (w *WriterOperator) findOperator(operators []operator.Operator, operatorID 
 
 // OutputIDs is a collection of operator IDs used as outputs.
 type OutputIDs []string
-
-func (o OutputIDs) WithNamespace(bc operator.BuildContext) OutputIDs {
-	namespacedIDs := make([]string, 0, len(o))
-	for _, id := range o {
-		namespacedIDs = append(namespacedIDs, bc.PrependNamespace(id))
-	}
-	return namespacedIDs
-}
 
 // UnmarshalJSON will unmarshal a string or array of strings to OutputIDs.
 func (o *OutputIDs) UnmarshalJSON(bytes []byte) error {

--- a/pipeline/config_test.go
+++ b/pipeline/config_test.go
@@ -191,7 +191,7 @@ func TestUpdateOutputIDs(t *testing.T) {
 				return ops
 			},
 			[]string{
-				"$.json_parser1",
+				"json_parser1",
 			},
 		},
 		{
@@ -205,9 +205,9 @@ func TestUpdateOutputIDs(t *testing.T) {
 				return ops
 			},
 			[]string{
-				"$.json_parser1",
-				"$.json_parser2",
-				"$.json_parser3",
+				"json_parser1",
+				"json_parser2",
+				"json_parser3",
 			},
 		},
 		{
@@ -222,10 +222,10 @@ func TestUpdateOutputIDs(t *testing.T) {
 				return ops
 			},
 			[]string{
-				"$.json_parser1",
-				"$.json_parser2",
-				"$.copy",
-				"$.copy1",
+				"json_parser1",
+				"json_parser2",
+				"copy",
+				"copy1",
 			},
 		},
 		{
@@ -239,9 +239,9 @@ func TestUpdateOutputIDs(t *testing.T) {
 				return ops
 			},
 			[]string{
-				"$.copy",
-				"$.json_parser1",
-				"$.copy1",
+				"copy",
+				"json_parser1",
+				"copy1",
 			},
 		},
 		{
@@ -256,10 +256,10 @@ func TestUpdateOutputIDs(t *testing.T) {
 				return ops
 			},
 			[]string{
-				"$.json_parser1",
-				"$.json_parser2",
-				"$.json_parser3",
-				"$.json_parser4",
+				"json_parser1",
+				"json_parser2",
+				"json_parser3",
+				"json_parser4",
 			},
 		},
 	}

--- a/testutil/mocks.go
+++ b/testutil/mocks.go
@@ -57,7 +57,7 @@ func (f *FakeOutput) CanOutput() bool { return false }
 func (f *FakeOutput) CanProcess() bool { return true }
 
 // ID always returns `fake` as the ID of a fake output operator
-func (f *FakeOutput) ID() string { return "$.fake" }
+func (f *FakeOutput) ID() string { return "fake" }
 
 // Logger returns the logger of a fake output
 func (f *FakeOutput) Logger() *zap.SugaredLogger { return f.SugaredLogger }

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -48,8 +48,7 @@ func NewTempDir(t testing.TB) string {
 // NewBuildContext will return a new build context for testing
 func NewBuildContext(t testing.TB) operator.BuildContext {
 	return operator.BuildContext{
-		Logger:    zaptest.NewLogger(t, zaptest.Level(zapcore.ErrorLevel)).Sugar(),
-		Namespace: "$",
+		Logger: zaptest.NewLogger(t, zaptest.Level(zapcore.ErrorLevel)).Sugar(),
 	}
 }
 


### PR DESCRIPTION
Namespaces were previously used to differentiate operators
within plugins or instances of plugins. The idea was to apply a
prefix to each operator id within a plugin. Nested plugins would have
multiple prefixes. In every case, the id would end up unique, barring
some extremely verbose manual naming (which would be caught at startup).
    
Many of these line changes are due to removal of the "root" namespace,
which was just a '$.' prefixed to each operator id.

Resolves #383 