### PR TITLE
fix iteration

### DIFF
--- a/operator/input/file/file.go
+++ b/operator/input/file/file.go
@@ -199,25 +199,30 @@ func (f *InputOperator) makeReaders(filesPaths []string) []*Reader {
 	// Exclude any empty fingerprints or duplicate fingerprints to avoid doubling up on copy-truncate files
 OUTER:
 	for i := 0; i < len(fps); i++ {
-		fp := fps[i]
-		if len(fp.FirstBytes) == 0 {
-			if err := files[i].Close(); err != nil {
-				f.Errorf("problem closing file", "file", files[i].Name())
-			}
-			// Empty file, don't read it until we can compare its fingerprint
-			fps = append(fps[:i], fps[i+1:]...)
-			files = append(files[:i], files[i+1:]...)
-		}
-		for j := i + 1; j < len(fps); j++ {
-			fp2 := fps[j]
-			if fp.StartsWith(fp2) || fp2.StartsWith(fp) {
-				// Exclude
+		if i < len(fps) {
+			fp := fps[i]
+			if len(fp.FirstBytes) == 0 {
 				if err := files[i].Close(); err != nil {
 					f.Errorf("problem closing file", "file", files[i].Name())
 				}
+				// Empty file, don't read it until we can compare its fingerprint
 				fps = append(fps[:i], fps[i+1:]...)
 				files = append(files[:i], files[i+1:]...)
-				continue OUTER
+				i--
+				continue
+			}
+			for j := i + 1; j < len(fps); j++ {
+				fp2 := fps[j]
+				if fp.StartsWith(fp2) || fp2.StartsWith(fp) {
+					// Exclude
+					if err := files[i].Close(); err != nil {
+						f.Errorf("problem closing file", "file", files[i].Name())
+					}
+					fps = append(fps[:i], fps[i+1:]...)
+					files = append(files[:i], files[i+1:]...)
+					i--
+					continue OUTER
+				}
 			}
 		}
 	}

--- a/operator/input/file/file_test.go
+++ b/operator/input/file/file_test.go
@@ -487,6 +487,30 @@ func TestSplitWrite(t *testing.T) {
 	waitForMessage(t, logReceived, "testlog1testlog2")
 }
 
+func TestIgnoreEmptyFiles(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	operator.persister = testutil.NewMockPersister("test")
+	defer operator.Stop()
+
+	temp := openTemp(t, tempDir)
+	temp2 := openTemp(t, tempDir)
+	temp3 := openTemp(t, tempDir)
+	temp4 := openTemp(t, tempDir)
+
+	writeString(t, temp, "testlog1\n")
+	writeString(t, temp3, "testlog2\n")
+	operator.poll(context.Background())
+
+	waitForMessages(t, logReceived, []string{"testlog1", "testlog2"})
+
+	writeString(t, temp2, "testlog3\n")
+	writeString(t, temp4, "testlog4\n")
+	operator.poll(context.Background())
+
+	waitForMessages(t, logReceived, []string{"testlog3", "testlog4"})
+}
+
 func TestDecodeBufferIsResized(t *testing.T) {
 	t.Parallel()
 	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)


### PR DESCRIPTION
Fixes #391 
with this change, data duplication is gone. 
it is iterating over an array, but we are removing elements from that very array, so it causes to skip the next element after removing. 