### PR TITLE
fix(helpers/multiline): fix force flushing with multiline

### DIFF
--- a/operator/helper/multiline.go
+++ b/operator/helper/multiline.go
@@ -314,10 +314,8 @@ func NewNewlineSplitFunc(encoding encoding.Encoding, flushAtEOF bool) (bufio.Spl
 		// Flush if no more data is expected
 		if atEOF && flushAtEOF {
 			token = trimWhitespaces(data)
-			if token != nil {
-				advance = len(data)
-				return
-			}
+			advance = len(data)
+			return
 		}
 
 		// Request more data.

--- a/operator/helper/multiline.go
+++ b/operator/helper/multiline.go
@@ -93,11 +93,6 @@ func (f *Flusher) SplitFunc(splitFunc bufio.SplitFunc) bufio.SplitFunc {
 			return
 		}
 
-		// Do not return empty log
-		if len(token) == 0 {
-			token = nil
-		}
-
 		// Return token
 		if token != nil {
 			// Inform flusher that we just flushed
@@ -311,11 +306,7 @@ func NewNewlineSplitFunc(encoding encoding.Encoding, flushAtEOF bool) (bufio.Spl
 			// We have a full newline-terminated line.
 			token = bytes.TrimSuffix(data[:i], carriageReturn)
 
-			if len(token) == 0 {
-				token = nil
-			}
-
-			return i + len(newline), token, nil
+			return i + len(newline), trimWhitespaces(token), nil
 		}
 
 		// Flush if no more data is expected

--- a/operator/helper/multiline.go
+++ b/operator/helper/multiline.go
@@ -235,22 +235,24 @@ func flusherSplitFunc(force *Flusher, splitFunc bufio.SplitFunc) bufio.SplitFunc
 			return
 		}
 
-		// If there is no token, force flush eventually
-		if force != nil {
-			if force.ShouldFlush() {
-				// Inform flusher that we just flushed
-				force.Flushed()
-				token = trimWhitespaces(data)
-				if len(token) == 0 {
-					token = nil
-				}
-				advance = len(data)
-				return
-			} else {
-				// Inform flusher that we didn't flushed
-				force.UpdateDataChangeTime(len(data))
-			}
+		if force == nil {
+			return
 		}
+
+		// If there is no token, force flush eventually
+		if force.ShouldFlush() {
+			// Inform flusher that we just flushed
+			force.Flushed()
+			token = trimWhitespaces(data)
+			if len(token) == 0 {
+				token = nil
+			}
+			advance = len(data)
+			return
+		}
+
+		// Inform flusher that we didn't flushed
+		force.UpdateDataChangeTime(len(data))
 		return
 	}
 }

--- a/operator/helper/multiline.go
+++ b/operator/helper/multiline.go
@@ -257,6 +257,9 @@ func flusherSplitFunc(force *Flusher, splitFunc bufio.SplitFunc) bufio.SplitFunc
 				// Inform flusher that we just flushed
 				force.Flushed()
 				token = trimWhitespaces(data)
+				if len(token) == 0 {
+					token = nil
+				}
 				advance = len(data)
 				return
 			} else {

--- a/operator/helper/multiline.go
+++ b/operator/helper/multiline.go
@@ -39,7 +39,11 @@ func NewFlusherConfig() FlusherConfig {
 
 // Build creates Flusher from configuration
 func (c *FlusherConfig) Build() *Flusher {
-	return NewFlusher(c.Period)
+	return &Flusher{
+		lastDataChange:     time.Now(),
+		forcePeriod:        c.Period.Raw(),
+		previousDataLength: 0,
+	}
 }
 
 // Flusher keeps information about flush state
@@ -55,16 +59,6 @@ type Flusher struct {
 	// if previousDataLength = 0 - no new data have been received after flush
 	// if previousDataLength > 0 - there is data which has not been flushed yet and it doesn't changed since lastDataChange
 	previousDataLength int
-}
-
-// NewFlusher Creates new Flusher with lastDataChange set to unix epoch
-// and order to not force ongoing flush
-func NewFlusher(forcePeriod Duration) *Flusher {
-	return &Flusher{
-		lastDataChange:     time.Now(),
-		forcePeriod:        forcePeriod.Raw(),
-		previousDataLength: 0,
-	}
 }
 
 func (f *Flusher) UpdateDataChangeTime(length int) {

--- a/operator/helper/multiline.go
+++ b/operator/helper/multiline.go
@@ -207,6 +207,8 @@ func NewLineStartSplitFunc(re *regexp.Regexp, flushAtEOF bool) bufio.SplitFunc {
 			// the beginning of the file does not match the start pattern, so return a token up to the first match so we don't lose data
 			advance = firstMatchStart
 			token = trimWhitespaces(data[0:firstMatchStart])
+
+			// return if non-matching pattern is not only whitespaces
 			if token != nil {
 				return
 			}

--- a/operator/helper/multiline.go
+++ b/operator/helper/multiline.go
@@ -80,6 +80,11 @@ func (f *Flusher) UpdateDataChangeTime(length int) {
 	f.lastDataChange = time.Now()
 }
 
+// Flushed reset data length
+func (f *Flusher) Flushed() {
+	f.UpdateDataChangeTime(-1)
+}
+
 // EnableForceFlush sets data length to 1 and doesn't touch lastDataChange
 func (f *Flusher) EnableForceFlush() {
 	f.previousDataLength = 1
@@ -159,14 +164,14 @@ func NewLineStartSplitFunc(re *regexp.Regexp, flushAtEOF bool, force *Flusher) b
 				advance = len(data)
 				if force != nil {
 					// Inform flusher that we just flushed
-					force.UpdateDataChangeTime(-1)
+					force.Flushed()
 				}
 				return
 			}
 			if force != nil {
 				if force.ShouldFlush() {
 					// Inform flusher that we just flushed
-					force.UpdateDataChangeTime(-1)
+					force.Flushed()
 					token = trimWhitespaces(data)
 					advance = len(data)
 					return
@@ -187,7 +192,7 @@ func NewLineStartSplitFunc(re *regexp.Regexp, flushAtEOF bool, force *Flusher) b
 			if len(token) > 0 {
 				if force != nil {
 					// Inform flusher that we just flushed
-					force.UpdateDataChangeTime(-1)
+					force.Flushed()
 				}
 				return
 			}
@@ -197,7 +202,7 @@ func NewLineStartSplitFunc(re *regexp.Regexp, flushAtEOF bool, force *Flusher) b
 			if force != nil {
 				if force.ShouldFlush() {
 					// Inform flusher that we just flushed
-					force.UpdateDataChangeTime(-1)
+					force.Flushed()
 					token = trimWhitespaces(data)
 					advance = len(data)
 					return
@@ -216,7 +221,7 @@ func NewLineStartSplitFunc(re *regexp.Regexp, flushAtEOF bool, force *Flusher) b
 			advance = len(data)
 			if force != nil {
 				// Inform flusher that we just flushed
-				force.UpdateDataChangeTime(-1)
+				force.Flushed()
 			}
 			return
 		}
@@ -227,7 +232,7 @@ func NewLineStartSplitFunc(re *regexp.Regexp, flushAtEOF bool, force *Flusher) b
 			if force != nil {
 				if force.ShouldFlush() {
 					// Inform flusher that we just flushed
-					force.UpdateDataChangeTime(-1)
+					force.Flushed()
 					token = trimWhitespaces(data)
 					advance = len(data)
 					return
@@ -245,7 +250,7 @@ func NewLineStartSplitFunc(re *regexp.Regexp, flushAtEOF bool, force *Flusher) b
 		err = nil
 		if force != nil {
 			// Inform flusher that we just flushed
-			force.UpdateDataChangeTime(-1)
+			force.Flushed()
 		}
 		return
 	}
@@ -281,14 +286,14 @@ func NewLineEndSplitFunc(re *regexp.Regexp, flushAtEOF bool, force *Flusher) buf
 				advance = len(data)
 				if force != nil {
 					// Inform flusher that we just flushed
-					force.UpdateDataChangeTime(-1)
+					force.Flushed()
 				}
 				return
 			}
 			if force != nil {
 				if force.ShouldFlush() {
 					// Inform flusher that we just flushed
-					force.UpdateDataChangeTime(-1)
+					force.Flushed()
 					token = trimWhitespaces(data)
 					advance = len(data)
 					return
@@ -306,7 +311,7 @@ func NewLineEndSplitFunc(re *regexp.Regexp, flushAtEOF bool, force *Flusher) buf
 			if force != nil {
 				if force.ShouldFlush() {
 					// Inform flusher that we just flushed
-					force.UpdateDataChangeTime(-1)
+					force.Flushed()
 					token = trimWhitespaces(data)
 					advance = len(data)
 					return
@@ -323,7 +328,7 @@ func NewLineEndSplitFunc(re *regexp.Regexp, flushAtEOF bool, force *Flusher) buf
 		err = nil
 		if force != nil {
 			// Inform flusher that we just flushed
-			force.UpdateDataChangeTime(-1)
+			force.Flushed()
 		}
 		return
 	}
@@ -346,7 +351,7 @@ func NewNewlineSplitFunc(encoding encoding.Encoding, flushAtEOF bool, force *Flu
 		if atEOF && len(data) == 0 {
 			// There is no data and we are waiting for more, so resetting change time
 			if force != nil {
-				force.UpdateDataChangeTime(-1)
+				force.Flushed()
 			}
 			return 0, nil, nil
 		}
@@ -362,7 +367,7 @@ func NewNewlineSplitFunc(encoding encoding.Encoding, flushAtEOF bool, force *Flu
 
 			// Inform flusher that we just flushed
 			if force != nil {
-				force.UpdateDataChangeTime(-1)
+				force.Flushed()
 			}
 
 			return i + len(newline), token, nil
@@ -382,7 +387,7 @@ func NewNewlineSplitFunc(encoding encoding.Encoding, flushAtEOF bool, force *Flu
 				advance = len(data)
 				if forceFlush {
 					// Inform flusher that we just flushed
-					force.UpdateDataChangeTime(-1)
+					force.Flushed()
 				}
 				return
 			}

--- a/operator/helper/multiline.go
+++ b/operator/helper/multiline.go
@@ -84,11 +84,6 @@ func (f *Flusher) Flushed() {
 	f.UpdateDataChangeTime(0)
 }
 
-// EnableForceFlush sets data length to 1 and doesn't touch lastDataChange
-func (f *Flusher) EnableForceFlush() {
-	f.previousDataLength = 1
-}
-
 // ShouldFlush returns true if data should be forcefully flushed
 func (f *Flusher) ShouldFlush() bool {
 	// Returns true if there is f.forcePeriod after f.lastDataChange and data length is greater than 0
@@ -244,11 +239,6 @@ func flusherSplitFunc(force *Flusher, splitFunc bufio.SplitFunc) bufio.SplitFunc
 				force.Flushed()
 			}
 			return
-		}
-
-		// Reset data length if there is no more data in file expected
-		if atEOF && force != nil {
-			force.EnableForceFlush()
 		}
 
 		// If there is no token, force flush eventually

--- a/operator/helper/multiline_test.go
+++ b/operator/helper/multiline_test.go
@@ -151,10 +151,7 @@ func TestLineStartSplitFunc(t *testing.T) {
 			Pattern:           `^LOGSTART \d+`,
 			Raw:               []byte("LOGPART log1\nLOGPART log1\t   \n"),
 			ExpectedTokenized: []string{},
-			Flusher: &Flusher{
-				force:           false,
-				lastForcedFlush: time.Now(),
-			},
+			Flusher:           &Flusher{},
 		},
 		{
 			Name:    "LogsWithFlusher",
@@ -164,8 +161,9 @@ func TestLineStartSplitFunc(t *testing.T) {
 				"LOGPART log1\nLOGPART log1",
 			},
 			Flusher: &Flusher{
-				force:           true,
-				lastForcedFlush: time.Now(),
+				previousDataLength: len("LOGPART log1\nLOGPART log1\t   \n"),
+				lastDataChange:     time.Unix(0, 0),
+				forcePeriod:        time.Nanosecond,
 			},
 		},
 		{
@@ -177,8 +175,9 @@ func TestLineStartSplitFunc(t *testing.T) {
 				"LOGSTART 123\nLOGPART log1",
 			},
 			Flusher: &Flusher{
-				force:           true,
-				lastForcedFlush: time.Now(),
+				forcePeriod:        time.Nanosecond,
+				lastDataChange:     time.Unix(0, 0),
+				previousDataLength: len("LOGPART log1\nLOGSTART 123\nLOGPART log1\t   \n"),
 			},
 		},
 	}
@@ -304,10 +303,7 @@ func TestLineEndSplitFunc(t *testing.T) {
 			Pattern:           `^LOGEND.*$`,
 			Raw:               []byte("LOGPART log1\nLOGPART log1\t   \n"),
 			ExpectedTokenized: []string{},
-			Flusher: &Flusher{
-				force:           false,
-				lastForcedFlush: time.Now(),
-			},
+			Flusher:           &Flusher{},
 		},
 		{
 			Name:    "LogsWithFlusher",
@@ -317,8 +313,9 @@ func TestLineEndSplitFunc(t *testing.T) {
 				"LOGPART log1\nLOGPART log1",
 			},
 			Flusher: &Flusher{
-				force:           true,
-				lastForcedFlush: time.Now(),
+				previousDataLength: len("LOGPART log1\nLOGPART log1\t   \n"),
+				lastDataChange:     time.Unix(0, 0),
+				forcePeriod:        time.Nanosecond,
 			},
 		},
 		{
@@ -330,8 +327,9 @@ func TestLineEndSplitFunc(t *testing.T) {
 				"LOGPART log1",
 			},
 			Flusher: &Flusher{
-				force:           true,
-				lastForcedFlush: time.Now(),
+				forcePeriod:        time.Nanosecond,
+				lastDataChange:     time.Unix(0, 0),
+				previousDataLength: len("LOGPART log1\nLOGEND\nLOGPART log1\t   \n"),
 			},
 		},
 	}
@@ -421,10 +419,7 @@ func TestNewlineSplitFunc(t *testing.T) {
 			Pattern:           `^LOGEND.*$`,
 			Raw:               []byte("LOGPART log1"),
 			ExpectedTokenized: []string{},
-			Flusher: &Flusher{
-				force:           false,
-				lastForcedFlush: time.Now(),
-			},
+			Flusher:           &Flusher{},
 		},
 		{
 			Name:    "LogsWithFlusher",
@@ -434,8 +429,9 @@ func TestNewlineSplitFunc(t *testing.T) {
 				"LOGPART log1",
 			},
 			Flusher: &Flusher{
-				force:           true,
-				lastForcedFlush: time.Now(),
+				previousDataLength: len("LOGPART log1"),
+				lastDataChange:     time.Unix(0, 0),
+				forcePeriod:        time.Nanosecond,
 			},
 		},
 		{
@@ -445,10 +441,7 @@ func TestNewlineSplitFunc(t *testing.T) {
 				"log1",
 				"log2",
 			},
-			Flusher: &Flusher{
-				force:           true,
-				lastForcedFlush: time.Now(),
-			},
+			Flusher: &Flusher{},
 		},
 	}
 

--- a/operator/helper/multiline_test.go
+++ b/operator/helper/multiline_test.go
@@ -640,6 +640,15 @@ func TestNewlineSplitFunc_Encodings(t *testing.T) {
 				{0, 108, 0, 111, 0, 103, 0, 50}, // log2
 			},
 		},
+		{
+			"MultiCarriageReturnUTF16StartingWithWhiteChars",
+			unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM),
+			[]byte{0, 13, 0, 10, 0, 108, 0, 111, 0, 103, 0, 49, 0, 13, 0, 10, 0, 108, 0, 111, 0, 103, 0, 50, 0, 13, 0, 10}, // \r\nlog1\r\nlog2\r\n
+			[][]byte{
+				{0, 108, 0, 111, 0, 103, 0, 49}, // log1
+				{0, 108, 0, 111, 0, 103, 0, 50}, // log2
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/operator/helper/multiline_test.go
+++ b/operator/helper/multiline_test.go
@@ -161,7 +161,7 @@ func TestLineStartSplitFunc(t *testing.T) {
 				"LOGPART log1\nLOGPART log1",
 			},
 			Flusher: &Flusher{
-				previousDataLength: len("LOGPART log1\nLOGPART log1\t   \n"),
+				previousDataLength: 0,
 				lastDataChange:     time.Unix(0, 0),
 				forcePeriod:        time.Nanosecond,
 			},
@@ -177,7 +177,7 @@ func TestLineStartSplitFunc(t *testing.T) {
 			Flusher: &Flusher{
 				forcePeriod:        time.Nanosecond,
 				lastDataChange:     time.Unix(0, 0),
-				previousDataLength: len("LOGPART log1\nLOGSTART 123\nLOGPART log1\t   \n"),
+				previousDataLength: 0,
 			},
 		},
 		{
@@ -326,7 +326,7 @@ func TestLineEndSplitFunc(t *testing.T) {
 				"LOGPART log1\nLOGPART log1",
 			},
 			Flusher: &Flusher{
-				previousDataLength: len("LOGPART log1\nLOGPART log1\t   \n"),
+				previousDataLength: 0,
 				lastDataChange:     time.Unix(0, 0),
 				forcePeriod:        time.Nanosecond,
 			},
@@ -342,7 +342,7 @@ func TestLineEndSplitFunc(t *testing.T) {
 			Flusher: &Flusher{
 				forcePeriod:        time.Nanosecond,
 				lastDataChange:     time.Unix(0, 0),
-				previousDataLength: len("LOGPART log1\nLOGEND\nLOGPART log1\t   \n"),
+				previousDataLength: 0,
 			},
 		},
 		{
@@ -453,7 +453,7 @@ func TestNewlineSplitFunc(t *testing.T) {
 				"LOGPART log1",
 			},
 			Flusher: &Flusher{
-				previousDataLength: len("LOGPART log1"),
+				previousDataLength: 0,
 				lastDataChange:     time.Unix(0, 0),
 				forcePeriod:        time.Nanosecond,
 			},

--- a/operator/helper/multiline_test.go
+++ b/operator/helper/multiline_test.go
@@ -180,6 +180,19 @@ func TestLineStartSplitFunc(t *testing.T) {
 				previousDataLength: len("LOGPART log1\nLOGSTART 123\nLOGPART log1\t   \n"),
 			},
 		},
+		{
+			Name:    "LogsWithFlusherWithLogStartingWithWhiteChars",
+			Pattern: `^LOGSTART \d+`,
+			Raw:     []byte("\nLOGSTART 333"),
+			ExpectedTokenized: []string{
+				"LOGSTART 333",
+			},
+			Flusher: &Flusher{
+				forcePeriod:        time.Nanosecond,
+				lastDataChange:     time.Unix(0, 0),
+				previousDataLength: -1,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -332,6 +345,19 @@ func TestLineEndSplitFunc(t *testing.T) {
 				previousDataLength: len("LOGPART log1\nLOGEND\nLOGPART log1\t   \n"),
 			},
 		},
+		{
+			Name:    "LogsWithFlusherWithLogStartingWithWhiteChars",
+			Pattern: `LOGEND \d+$`,
+			Raw:     []byte("\nLOGEND 333"),
+			ExpectedTokenized: []string{
+				"LOGEND 333",
+			},
+			Flusher: &Flusher{
+				forcePeriod:        time.Nanosecond,
+				lastDataChange:     time.Unix(0, 0),
+				previousDataLength: -1,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -416,15 +442,13 @@ func TestNewlineSplitFunc(t *testing.T) {
 		},
 		{
 			Name:              "LogsWithoutFlusher",
-			Pattern:           `^LOGEND.*$`,
 			Raw:               []byte("LOGPART log1"),
 			ExpectedTokenized: []string{},
 			Flusher:           &Flusher{},
 		},
 		{
-			Name:    "LogsWithFlusher",
-			Pattern: `^LOGEND.*$`,
-			Raw:     []byte("LOGPART log1"),
+			Name: "LogsWithFlusher",
+			Raw:  []byte("LOGPART log1"),
 			ExpectedTokenized: []string{
 				"LOGPART log1",
 			},
@@ -442,6 +466,18 @@ func TestNewlineSplitFunc(t *testing.T) {
 				"log2",
 			},
 			Flusher: &Flusher{},
+		},
+		{
+			Name: "LogsWithFlusherWithLogStartingWithWhiteChars",
+			Raw:  []byte("\nLOGEND 333"),
+			ExpectedTokenized: []string{
+				"LOGEND 333",
+			},
+			Flusher: &Flusher{
+				forcePeriod:        time.Nanosecond,
+				lastDataChange:     time.Unix(0, 0),
+				previousDataLength: -1,
+			},
 		},
 	}
 

--- a/operator/helper/multiline_test.go
+++ b/operator/helper/multiline_test.go
@@ -168,6 +168,19 @@ func TestLineStartSplitFunc(t *testing.T) {
 				lastForcedFlush: time.Now(),
 			},
 		},
+		{
+			Name:    "LogsWithFlusherWithMultipleLogsInBuffer",
+			Pattern: `^LOGSTART \d+`,
+			Raw:     []byte("LOGPART log1\nLOGSTART 123\nLOGPART log1\t   \n"),
+			ExpectedTokenized: []string{
+				"LOGPART log1",
+				"LOGSTART 123\nLOGPART log1",
+			},
+			Flusher: &Flusher{
+				force:           true,
+				lastForcedFlush: time.Now(),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -302,6 +315,19 @@ func TestLineEndSplitFunc(t *testing.T) {
 			Raw:     []byte("LOGPART log1\nLOGPART log1\t   \n"),
 			ExpectedTokenized: []string{
 				"LOGPART log1\nLOGPART log1",
+			},
+			Flusher: &Flusher{
+				force:           true,
+				lastForcedFlush: time.Now(),
+			},
+		},
+		{
+			Name:    "LogsWithFlusherWithMultipleLogsInBuffer",
+			Pattern: `^LOGEND.*$`,
+			Raw:     []byte("LOGPART log1\nLOGEND\nLOGPART log1\t   \n"),
+			ExpectedTokenized: []string{
+				"LOGPART log1\nLOGEND",
+				"LOGPART log1",
 			},
 			Flusher: &Flusher{
 				force:           true,

--- a/operator/helper/multiline_test.go
+++ b/operator/helper/multiline_test.go
@@ -469,9 +469,10 @@ func TestNewlineSplitFunc(t *testing.T) {
 		},
 		{
 			Name: "LogsWithFlusherWithLogStartingWithWhiteChars",
-			Raw:  []byte("\nLOGEND 333"),
+			Raw:  []byte("\nLOGEND 333\nAnother one"),
 			ExpectedTokenized: []string{
 				"LOGEND 333",
+				"Another one",
 			},
 			Flusher: &Flusher{
 				forcePeriod:        time.Nanosecond,

--- a/operator/input/file/reader.go
+++ b/operator/input/file/reader.go
@@ -136,13 +136,8 @@ func (r *Reader) ReadToEnd(ctx context.Context) {
 			if err := getScannerError(scanner); err != nil {
 				r.Errorw("Failed during scan", zap.Error(err))
 			}
-
-			// Force flush eventually in next iteration
-			r.splitter.CheckAndFlush()
 			break
 		}
-		// Update information about last flush time
-		r.splitter.Flushed()
 
 		if err := r.emit(ctx, scanner.Bytes()); err != nil {
 			r.Error("Failed to emit entry", zap.Error(err))


### PR DESCRIPTION
I found an issue with multiline and force flushing. If `forcePeriod` is low, then sometimes logs buffer (data) have been pushed without proper multiline detection (just force flushed).

In order to fix that issue, I changed the `forceFlusher` to be oriented on changes inside `splitFunc`. It uses two variables to track changes:
* `lastDataChange` which keeps timestamp of last change (flush, new data, basically change in data)
* `previousDataLength` which keep length of data with `-1` as special variable (which means that data have been flushed, what prevents to force flush in case data changed but it length does not)

The splitFuncs are rather complicated, so I'm mostly relaying on unit tests

---

In order to reproduce the issue which started all of the changes

main.py
```python
import time

LOG='Mar 14 22:00:14 ip-11-11-11-111 sadd[25288]: asdasdasdfadfdsgasdgb asd asd asd sad asd asd asd as s'

with open('test.log', 'w') as f:
    for i in range(10):
        for i in range(5):
            f.write(LOG)
            f.write('\n')
        f.flush()
        time.sleep(0.3)

```

config.yaml
```yaml
receivers:
  filelog/syslog:
    start_at: beginning
    include_file_path_resolved: true
    include_file_name: false
    force_flush_period: 50ms
    max_log_size: 32MiB  # increase max_log_size to scrape long lines
    include:
      - ./test.log
    multiline:
      line_start_pattern: \w{3}\s+\d{1,2} \d{2}:\d{2}:\d{2}
    operators:
      - type: regex_parser
        regex: (?P<timestamp>\w{3}\s+\d{1,2} \d{2}:\d{2}:\d{2})
        preserve_to: $$body.log
        timestamp:
          parse_from: $$body.timestamp
          layout_type: gotime
          layout: Jan _2 15:04:05
      - type: restructure
        ops:
          - move:
              from: $$body.log
              to: $$body
    attributes:
      _a: syslog
      _b: syslog
      c: syslog
    resource:
      _d: otelcol
      e: otelcol
      f: otelcol
      g: otelcol
      h: otelcol
exporters:
  logging:
    logLevel: debug
service:
  pipelines:
    logs:
      receivers:
        - filelog/syslog
      exporters:
        - logging

```