### PR TITLE
Remove notion of a default timestamp

### DIFF
--- a/entry/entry.go
+++ b/entry/entry.go
@@ -16,29 +16,10 @@ package entry
 
 import (
 	"fmt"
-	"os"
 	"time"
 )
 
-const defaultTimestampEnv = "STANZA_DEFAULT_TIMESTAMP"
-
-func getNow() func() time.Time {
-	env := os.Getenv(defaultTimestampEnv)
-	if env == "" {
-		return time.Now
-	}
-
-	parsed, err := time.Parse(time.RFC3339, env)
-	if err != nil {
-		panic(fmt.Sprintf("failed parsing default timestamp: %s", err))
-	}
-
-	return func() time.Time {
-		return parsed
-	}
-}
-
-var now = getNow()
+var now = time.Now
 
 // Entry is a flexible representation of log data associated with a timestamp.
 type Entry struct {

--- a/entry/entry_test.go
+++ b/entry/entry_test.go
@@ -15,7 +15,6 @@
 package entry
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -284,16 +283,4 @@ func TestReadToInterfaceMissingField(t *testing.T) {
 	err := entry.readToInterface(field, &dest)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "can not be read as a interface{}")
-}
-
-func TestDefaultTimestamp(t *testing.T) {
-	os.Setenv(defaultTimestampEnv, "2019-10-12T07:20:50.52Z")
-	now = getNow()
-	defer func() { now = getNow() }()
-	defer os.Unsetenv(defaultTimestampEnv)
-
-	e := New()
-	expected := time.Date(2019, 10, 12, 7, 20, 50, int(520*time.Millisecond), time.UTC)
-	require.Equal(t, expected, e.Timestamp)
-	require.True(t, e.Timestamp.Equal(expected))
 }


### PR DESCRIPTION
This was a vestigial feature and can be removed without any impact.