### PR TITLE
Remove preserve_to

### DIFF
--- a/operator/helper/parser.go
+++ b/operator/helper/parser.go
@@ -57,7 +57,6 @@ func (c ParserConfig) Build(logger *zap.SugaredLogger) (ParserOperator, error) {
 		TransformerOperator: transformerOperator,
 		ParseFrom:           c.ParseFrom,
 		ParseTo:             c.ParseTo,
-		PreserveTo:          c.PreserveTo,
 	}
 
 	if c.TimeParser != nil {
@@ -94,7 +93,6 @@ type ParserOperator struct {
 	TransformerOperator
 	ParseFrom       entry.Field
 	ParseTo         entry.Field
-	PreserveTo      *entry.Field
 	TimeParser      *TimeParser
 	SeverityParser  *SeverityParser
 	TraceParser     *TraceParser
@@ -148,16 +146,8 @@ func (p *ParserOperator) ParseWith(ctx context.Context, entry *entry.Entry, pars
 		return p.HandleEntryError(ctx, entry, err)
 	}
 
-	original, _ := entry.Delete(p.ParseFrom)
-
 	if err := entry.Set(p.ParseTo, newValue); err != nil {
 		return p.HandleEntryError(ctx, entry, errors.Wrap(err, "set parse_to"))
-	}
-
-	if p.PreserveTo != nil {
-		if err := entry.Set(p.PreserveTo, original); err != nil {
-			return p.HandleEntryError(ctx, entry, errors.Wrap(err, "set preserve_to"))
-		}
 	}
 
 	var timeParseErr error

--- a/operator/helper/parser_test.go
+++ b/operator/helper/parser_test.go
@@ -406,6 +406,7 @@ func TestParserFields(t *testing.T) {
 			func() *entry.Entry {
 				e := entry.New()
 				e.ObservedTimestamp = now
+				e.Body = keyValue
 				e.Attributes = map[string]interface{}{
 					"key": "value",
 				}
@@ -426,6 +427,7 @@ func TestParserFields(t *testing.T) {
 			func() *entry.Entry {
 				e := entry.New()
 				e.ObservedTimestamp = now
+				e.Body = keyValue
 				e.Resource = map[string]interface{}{
 					"key": "value",
 				}
@@ -470,6 +472,7 @@ func TestParserFields(t *testing.T) {
 			func() *entry.Entry {
 				e := entry.New()
 				e.ObservedTimestamp = now
+				e.Body = keyValue
 				e.Attributes = map[string]interface{}{
 					"one": map[string]interface{}{
 						"two": map[string]interface{}{
@@ -494,6 +497,7 @@ func TestParserFields(t *testing.T) {
 			func() *entry.Entry {
 				e := entry.New()
 				e.ObservedTimestamp = now
+				e.Body = keyValue
 				e.Resource = map[string]interface{}{
 					"one": map[string]interface{}{
 						"two": map[string]interface{}{
@@ -523,7 +527,9 @@ func TestParserFields(t *testing.T) {
 				e := entry.New()
 				e.ObservedTimestamp = now
 				e.Body = map[string]interface{}{
-					"one": map[string]interface{}{},
+					"one": map[string]interface{}{
+						"two": keyValue,
+					},
 				}
 				e.Attributes = map[string]interface{}{
 					"key": "value",
@@ -551,7 +557,9 @@ func TestParserFields(t *testing.T) {
 				e.ObservedTimestamp = now
 				e.Attributes = map[string]interface{}{
 					"key": "value",
-					"one": map[string]interface{}{},
+					"one": map[string]interface{}{
+						"two": keyValue,
+					},
 				}
 				return e
 			},
@@ -578,175 +586,9 @@ func TestParserFields(t *testing.T) {
 					"key": "value",
 				}
 				e.Resource = map[string]interface{}{
-					"one": map[string]interface{}{},
-				}
-				return e
-			},
-		},
-		{
-			"AllFields",
-			func(cfg *ParserConfig) {
-				cfg.ParseFrom = entry.NewBodyField("one", "two")
-				cfg.ParseTo = entry.NewAttributeField()
-				dst := entry.NewResourceField("foo")
-				cfg.PreserveTo = &dst
-			},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Body = map[string]interface{}{
 					"one": map[string]interface{}{
 						"two": keyValue,
 					},
-				}
-				return e
-			},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Body = map[string]interface{}{
-					"one": map[string]interface{}{},
-				}
-				e.Attributes = map[string]interface{}{
-					"key": "value",
-				}
-				e.Resource = map[string]interface{}{
-					"foo": keyValue,
-				}
-				return e
-			},
-		},
-		{
-			"NoPreserve",
-			func(cfg *ParserConfig) {},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Body = keyValue
-				return e
-			},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Attributes = map[string]interface{}{"key": "value"}
-				return e
-			},
-		},
-		{
-			"PreserveToSubkey",
-			func(cfg *ParserConfig) {
-				dst := entry.NewBodyField("original")
-				cfg.PreserveTo = &dst
-			},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Body = keyValue
-				return e
-			},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Body = map[string]interface{}{
-					"original": keyValue,
-				}
-				e.Attributes = map[string]interface{}{
-					"key": "value",
-				}
-				return e
-			},
-		},
-		{
-			"PreserveToOverwrite",
-			func(cfg *ParserConfig) {
-				dst := entry.NewAttributeField("key")
-				cfg.PreserveTo = &dst
-			},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Body = keyValue
-				return e
-			},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Attributes = map[string]interface{}{
-					"key": keyValue,
-				}
-				return e
-			},
-		},
-		{
-			"PreserveToRoot",
-			func(cfg *ParserConfig) {
-				dst := entry.NewBodyField()
-				cfg.PreserveTo = &dst
-			},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Body = keyValue
-				return e
-			},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Body = keyValue
-				e.Attributes = map[string]interface{}{
-					"key": "value",
-				}
-				return e
-			},
-		},
-		{
-			"AlternativeParseFrom",
-			func(cfg *ParserConfig) {
-				dst := entry.NewBodyField("source")
-				cfg.PreserveTo = &dst
-				cfg.ParseFrom = dst
-			},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Body = map[string]interface{}{
-					"source": keyValue,
-				}
-				return e
-			},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Body = map[string]interface{}{
-					"source": keyValue,
-				}
-				e.Attributes = map[string]interface{}{
-					"key": "value",
-				}
-				return e
-			},
-		},
-		{
-			"AlternativeParseTo",
-			func(cfg *ParserConfig) {
-				dst := entry.NewBodyField("original")
-				cfg.PreserveTo = &dst
-				cfg.ParseTo = entry.NewBodyField("source_parsed")
-			},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Body = keyValue
-				return e
-			},
-			func() *entry.Entry {
-				e := entry.New()
-				e.ObservedTimestamp = now
-				e.Body = map[string]interface{}{
-					"source_parsed": map[string]interface{}{
-						"key": "value",
-					},
-					"original": keyValue,
 				}
 				return e
 			},

--- a/operator/parser/csv/csv_test.go
+++ b/operator/parser/csv/csv_test.go
@@ -103,6 +103,7 @@ func TestParserCSV(t *testing.T) {
 			},
 			[]entry.Entry{
 				{
+					Body: "stanza,INFO,started agent",
 					Attributes: map[string]interface{}{
 						"name": "stanza",
 						"sev":  "INFO",
@@ -131,6 +132,7 @@ func TestParserCSV(t *testing.T) {
 			},
 			[]entry.Entry{
 				{
+					Body: "stanza,INFO,started agent",
 					Attributes: map[string]interface{}{
 						"name": "stanza",
 						"sev":  "INFO",
@@ -138,6 +140,7 @@ func TestParserCSV(t *testing.T) {
 					},
 				},
 				{
+					Body: "stanza,ERROR,agent killed",
 					Attributes: map[string]interface{}{
 						"name": "stanza",
 						"sev":  "ERROR",
@@ -145,6 +148,7 @@ func TestParserCSV(t *testing.T) {
 					},
 				},
 				{
+					Body: "kernel,TRACE,oom",
 					Attributes: map[string]interface{}{
 						"name": "kernel",
 						"sev":  "TRACE",
@@ -168,6 +172,7 @@ func TestParserCSV(t *testing.T) {
 			},
 			[]entry.Entry{
 				{
+					Body: "stanza;Evergreen;1;555-5555;agent",
 					Attributes: map[string]interface{}{
 						"name":     "stanza",
 						"address":  "Evergreen",
@@ -203,6 +208,7 @@ func TestParserCSV(t *testing.T) {
 						"height": "400",
 						"number": "555-555-5555",
 					},
+					Body: "stanza dev,1,400,555-555-5555",
 				},
 			},
 			false,
@@ -243,6 +249,7 @@ func TestParserCSV(t *testing.T) {
 						"height": "400",
 						"number": "555-555-5555",
 					},
+					Body: "stanza dev,1,400,555-555-5555",
 				},
 				{
 					Attributes: map[string]interface{}{
@@ -250,6 +257,7 @@ func TestParserCSV(t *testing.T) {
 						"x":      "000100",
 						"y":      "2",
 					},
+					Body: "000100,2",
 				},
 				{
 					Attributes: map[string]interface{}{
@@ -261,6 +269,7 @@ func TestParserCSV(t *testing.T) {
 						"e":      "5",
 						"f":      "6",
 					},
+					Body: "1,2,3,4,5,6",
 				},
 			},
 			false,
@@ -289,6 +298,7 @@ func TestParserCSV(t *testing.T) {
 						"height": "400",
 						"number": "555-555-5555",
 					},
+					Body: "stanza dev	1	400	555-555-5555",
 				},
 			},
 			false,
@@ -365,6 +375,7 @@ func TestParserCSV(t *testing.T) {
 						"object":       "",
 						"retcode":      "0",
 					},
+					Body: "20210316 17:08:01,oiq-int-mysql,load,oiq-int-mysql.bluemedora.localnet,5,0,DISCONNECT,,,0",
 				},
 			},
 			false,
@@ -389,6 +400,7 @@ func TestParserCSV(t *testing.T) {
 						"phone":    "555-5555",
 						"position": "agent",
 					},
+					Body: "stanza,Evergreen,,555-5555,agent",
 				},
 			},
 			false,
@@ -414,6 +426,7 @@ func TestParserCSV(t *testing.T) {
 						"phone":    "555-5555",
 						"position": "agent",
 					},
+					Body: "stanza	Evergreen	1	555-5555	agent",
 				},
 			},
 			false,
@@ -438,6 +451,7 @@ func TestParserCSV(t *testing.T) {
 						"phone":    "555-5555",
 						"position": "agent",
 					},
+					Body: "stanza,\"Evergreen,49508\",1,555-5555,agent",
 				},
 			},
 			false,
@@ -462,6 +476,7 @@ func TestParserCSV(t *testing.T) {
 						"phone":    "555-5555",
 						"position": "agent",
 					},
+					Body: "\"bob \"\"the man\"\"\",Evergreen,1,555-5555,agent",
 				},
 			},
 			false,
@@ -486,6 +501,7 @@ func TestParserCSV(t *testing.T) {
 						"height": "400",
 						"number": "555-555-5555",
 					},
+					Body: "stanza,1,400,555-555-5555",
 				},
 			},
 			true,
@@ -511,6 +527,7 @@ func TestParserCSV(t *testing.T) {
 						"height": "400",
 						"number": "555-555-5555",
 					},
+					Body: "stanza,1,400,555-555-5555",
 				},
 			},
 			true,
@@ -535,6 +552,7 @@ func TestParserCSV(t *testing.T) {
 						"height": "400",
 						"number": "555-555-5555",
 					},
+					Body: "1,400,555-555-5555",
 				},
 			},
 			false,
@@ -584,6 +602,7 @@ func TestParserCSV(t *testing.T) {
 						"height": "6ft",
 						"number": "5",
 					},
+					Body: "stanza \"log parser\",1,6ft,5",
 				},
 			},
 			false,

--- a/operator/parser/keyvalue/keyvalue_test.go
+++ b/operator/parser/keyvalue/keyvalue_test.go
@@ -174,6 +174,7 @@ func TestKVParser(t *testing.T) {
 					"name": "stanza",
 					"age":  "2",
 				},
+				Body: "name=stanza age=2",
 			},
 			false,
 			false,
@@ -189,10 +190,12 @@ func TestKVParser(t *testing.T) {
 				},
 			},
 			&entry.Entry{
-				Body: map[string]interface{}{},
 				Attributes: map[string]interface{}{
 					"name": "otel",
 					"age":  "2",
+				},
+				Body: map[string]interface{}{
+					"test": "name=otel age=2",
 				},
 			},
 			false,
@@ -218,49 +221,25 @@ func TestKVParser(t *testing.T) {
 			false,
 		},
 		{
-			"preserve-to",
+			"from-to",
 			func(kv *KVParserConfig) {
-				preserveTo := entry.NewBodyField("test")
-				kv.PreserveTo = &preserveTo
+				kv.ParseFrom = entry.NewAttributeField("from")
+				kv.ParseTo = entry.NewBodyField("to")
 			},
 			&entry.Entry{
-				Body: "name=stanza age=10",
-			},
-			&entry.Entry{
-				Body: map[string]interface{}{
-					"test": "name=stanza age=10",
-				},
 				Attributes: map[string]interface{}{
-					"name": "stanza",
-					"age":  "10",
-				},
-			},
-			false,
-			false,
-		},
-		{
-			"from-to-preserve",
-			func(kv *KVParserConfig) {
-				kv.ParseFrom = entry.NewBodyField("from")
-				kv.ParseTo = entry.NewAttributeField("to")
-				orig := entry.NewResourceField("orig")
-				kv.PreserveTo = &orig
-			},
-			&entry.Entry{
-				Body: map[string]interface{}{
 					"from": "name=stanza age=10",
 				},
 			},
 			&entry.Entry{
-				Body: map[string]interface{}{},
 				Attributes: map[string]interface{}{
+					"from": "name=stanza age=10",
+				},
+				Body: map[string]interface{}{
 					"to": map[string]interface{}{
 						"name": "stanza",
 						"age":  "10",
 					},
-				},
-				Resource: map[string]interface{}{
-					"orig": "name=stanza age=10",
 				},
 			},
 			false,
@@ -276,6 +255,7 @@ func TestKVParser(t *testing.T) {
 				Attributes: map[string]interface{}{
 					"requestClientApplication": `Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0`,
 				},
+				Body: `requestClientApplication="Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0"`,
 			},
 			false,
 			false,
@@ -291,6 +271,7 @@ func TestKVParser(t *testing.T) {
 					"name": "stanza",
 					"age":  "2",
 				},
+				Body: "name=\"stanza\" age=2",
 			},
 			false,
 			false,
@@ -306,6 +287,7 @@ func TestKVParser(t *testing.T) {
 					"description": "stanza deployment number 5",
 					"x":           "y",
 				},
+				Body: "description='stanza deployment number 5' x=y",
 			},
 			false,
 			false,
@@ -321,6 +303,7 @@ func TestKVParser(t *testing.T) {
 					"name": "stanza",
 					"age":  "2",
 				},
+				Body: `name=" stanza " age=2`,
 			},
 			false,
 			false,
@@ -336,6 +319,7 @@ func TestKVParser(t *testing.T) {
 					"name": "stanza",
 					"age":  "2",
 				},
+				Body: `" name "=" stanza " age=2`,
 			},
 			false,
 			false,
@@ -354,6 +338,7 @@ func TestKVParser(t *testing.T) {
 			},
 			&entry.Entry{
 				Body: map[string]interface{}{
+					"testfield": `name|" stanza " age|2     key|value`,
 					"testparsed": map[string]interface{}{
 						"name": "stanza",
 						"age":  "2",
@@ -378,6 +363,7 @@ func TestKVParser(t *testing.T) {
 					"age":  "2",
 					"key":  "value",
 				},
+				Body: `name==" stanza " age==2     key==value`,
 			},
 			false,
 			false,
@@ -396,6 +382,7 @@ func TestKVParser(t *testing.T) {
 					"age":  "2",
 					"key":  "value",
 				},
+				Body: `name=stanza|age=2     | key=value`,
 			},
 			false,
 			false,
@@ -420,6 +407,7 @@ func TestKVParser(t *testing.T) {
 					"translated_port":   "57112",
 					"translated_src_ip": "96.63.176.3",
 				},
+				Body: "name=stanza age=1 job=\"software engineering\" location=\"grand rapids michigan\" src=\"10.3.3.76\" dst=172.217.0.10 protocol=udp sport=57112 dport=443 translated_src_ip=96.63.176.3 translated_port=57112",
 			},
 			false,
 			false,
@@ -461,6 +449,7 @@ func TestKVParser(t *testing.T) {
 					"note":     "Policy: a0, Info: 888",
 					"n":        "3412158",
 				},
+				Body: `id=LVM_Sonicwall sn=22255555 time="2021-09-22 16:30:31" fw=14.165.177.10 pri=6 c=1024 gcat=2 m=97 msg="Web site hit" srcMac=6c:0b:84:3f:fa:63 src=192.168.50.2:52006:X0 srcZone=LAN natSrc=14.165.177.10:58457 dstMac=08:b2:58:46:30:54 dst=15.159.150.83:443:X1 dstZone=WAN natDst=15.159.150.83:443 proto=tcp/https sent=1422 rcvd=5993 rule="6 (LAN->WAN)" app=48 dstname=example.space.dev.com arg=/ code=27 Category="Information Technology/Computers" note="Policy: a0, Info: 888 " n=3412158`,
 			},
 			false,
 			false,
@@ -471,7 +460,9 @@ func TestKVParser(t *testing.T) {
 			&entry.Entry{
 				Body: `test text`,
 			},
-			&entry.Entry{},
+			&entry.Entry{
+				Body: `test text`,
+			},
 			true,
 			false,
 		},
@@ -482,7 +473,7 @@ func TestKVParser(t *testing.T) {
 				Body: `test=text=abc`,
 			},
 			&entry.Entry{
-				Attributes: map[string]interface{}{},
+				Body: `test=text=abc`,
 			},
 			true,
 			false,
@@ -504,7 +495,9 @@ func TestKVParser(t *testing.T) {
 			&entry.Entry{
 				Body: "a=b c=d",
 			},
-			&entry.Entry{},
+			&entry.Entry{
+				Body: "a=b c=d",
+			},
 			false,
 			true,
 		},
@@ -517,7 +510,9 @@ func TestKVParser(t *testing.T) {
 			&entry.Entry{
 				Body: "a=b c=d",
 			},
-			&entry.Entry{},
+			&entry.Entry{
+				Body: "a=b c=d",
+			},
 			false,
 			true,
 		},

--- a/operator/parser/regex/regex_test.go
+++ b/operator/parser/regex/regex_test.go
@@ -81,6 +81,7 @@ func TestParserRegex(t *testing.T) {
 				Body: "a=b",
 			},
 			&entry.Entry{
+				Body: "a=b",
 				Attributes: map[string]interface{}{
 					"a": "b",
 				},

--- a/operator/parser/syslog/data.go
+++ b/operator/parser/syslog/data.go
@@ -73,6 +73,7 @@ func CreateCases(basicConfig func() *SyslogParserConfig) ([]Case, error) {
 					"message":  "test message",
 					"priority": 34,
 				},
+				Body: "<34>Jan 12 06:30:00 1.2.3.4 apache_server: test message",
 			},
 		},
 		{
@@ -97,6 +98,7 @@ func CreateCases(basicConfig func() *SyslogParserConfig) ([]Case, error) {
 					"message":  "test message",
 					"priority": 34,
 				},
+				Body: "<34>Jan 12 06:30:00 1.2.3.4 apache_server: test message",
 			},
 		},
 		{
@@ -121,6 +123,7 @@ func CreateCases(basicConfig func() *SyslogParserConfig) ([]Case, error) {
 					"message":  "test message",
 					"priority": 34,
 				},
+				Body: "<34>Jan 12 06:30:00 1.2.3.4 apache_server: test message",
 			},
 		},
 		{
@@ -155,6 +158,7 @@ func CreateCases(basicConfig func() *SyslogParserConfig) ([]Case, error) {
 					},
 					"version": 1,
 				},
+				Body: `<86>1 2015-08-05T21:58:59.693Z 192.168.2.132 SecureAuth0 23108 ID52020 [SecureAuth@27389 UserHostAddress="192.168.2.132" Realm="SecureAuth0" UserID="Tester2" PEN="27389"] Found the user for retrieving user's profile`,
 			},
 		},
 	}

--- a/operator/parser/uri/uri_test.go
+++ b/operator/parser/uri/uri_test.go
@@ -98,6 +98,7 @@ func TestProcess(t *testing.T) {
 					},
 					"scheme": "https",
 				},
+				Body: "https://google.com:443/path?user=dev",
 			},
 		},
 		{
@@ -115,6 +116,7 @@ func TestProcess(t *testing.T) {
 			},
 			&entry.Entry{
 				Body: map[string]interface{}{
+					"url": "https://google.com:443/path?user=dev",
 					"url2": map[string]interface{}{
 						"host": "google.com",
 						"port": "443",
@@ -142,7 +144,9 @@ func TestProcess(t *testing.T) {
 				},
 			},
 			&entry.Entry{
-				Body: map[string]interface{}{},
+				Body: map[string]interface{}{
+					"url": "https://google.com:443/path?user=dev",
+				},
 				Attributes: map[string]interface{}{
 					"host": "google.com",
 					"port": "443",


### PR DESCRIPTION
Resolves #431.

Removes the `preserve_to` setting from parsers.

Parsers no longer remove the `parse_from` field, unless promoting the value to a top-level field. (eg `timestamp`, `severity`, `scope`, `trace`)