### PR TITLE
Fix issue where scope name parser would fail to initialize

### DIFF
--- a/operator/helper/parser.go
+++ b/operator/helper/parser.go
@@ -82,6 +82,10 @@ func (c ParserConfig) Build(logger *zap.SugaredLogger) (ParserOperator, error) {
 		parserOperator.TraceParser = c.TraceParser
 	}
 
+	if c.ScopeNameParser != nil {
+		parserOperator.ScopeNameParser = c.ScopeNameParser
+	}
+
 	return parserOperator, nil
 }
 
@@ -171,9 +175,9 @@ func (p *ParserOperator) ParseWith(ctx context.Context, entry *entry.Entry, pars
 		traceParseErr = p.TraceParser.Parse(entry)
 	}
 
-	var logernameParserErr error
+	var scopeNameParserErr error
 	if p.ScopeNameParser != nil {
-		logernameParserErr = p.ScopeNameParser.Parse(entry)
+		scopeNameParserErr = p.ScopeNameParser.Parse(entry)
 	}
 
 	// Handle time or severity parsing errors after attempting to parse both
@@ -186,8 +190,8 @@ func (p *ParserOperator) ParseWith(ctx context.Context, entry *entry.Entry, pars
 	if traceParseErr != nil {
 		return p.HandleEntryError(ctx, entry, errors.Wrap(traceParseErr, "trace parser"))
 	}
-	if logernameParserErr != nil {
-		return p.HandleEntryError(ctx, entry, errors.Wrap(logernameParserErr, "scope_name parser"))
+	if scopeNameParserErr != nil {
+		return p.HandleEntryError(ctx, entry, errors.Wrap(scopeNameParserErr, "scope_name parser"))
 	}
 	return nil
 }

--- a/operator/helper/parser_test.go
+++ b/operator/helper/parser_test.go
@@ -54,14 +54,46 @@ func TestParserConfigInvalidTimeParser(t *testing.T) {
 
 func TestParserConfigBuildValid(t *testing.T) {
 	cfg := NewParserConfig("test-id", "test-type")
-	f := entry.NewBodyField("timestamp")
+
+	timeField := entry.NewBodyField("timestamp")
 	cfg.TimeParser = &TimeParser{
-		ParseFrom:  &f,
+		ParseFrom:  &timeField,
 		Layout:     "",
 		LayoutType: "native",
 	}
-	_, err := cfg.Build(testutil.Logger(t))
+
+	sevField := entry.NewBodyField("timestamp")
+	cfg.SeverityParserConfig = &SeverityParserConfig{
+		ParseFrom: &sevField,
+	}
+
+	traceIdField := entry.NewBodyField("trace_id")
+	spanIdField := entry.NewBodyField("span_id")
+	traceFlagsField := entry.NewBodyField("trace_flags")
+	cfg.TraceParser = &TraceParser{
+		TraceId: &TraceIdConfig{
+			ParseFrom: &traceIdField,
+		},
+		SpanId: &SpanIdConfig{
+			ParseFrom: &spanIdField,
+		},
+		TraceFlags: &TraceFlagsConfig{
+			ParseFrom: &traceFlagsField,
+		},
+	}
+
+	scopeNameField := entry.NewBodyField("logger")
+	cfg.ScopeNameParser = &ScopeNameParser{
+		ParseFrom: scopeNameField,
+	}
+
+	op, err := cfg.Build(testutil.Logger(t))
 	require.NoError(t, err)
+
+	require.NotNil(t, op.TimeParser)
+	require.NotNil(t, op.SeverityParser)
+	require.NotNil(t, op.TraceParser)
+	require.NotNil(t, op.ScopeNameParser)
 }
 
 func TestParserMissingField(t *testing.T) {


### PR DESCRIPTION
This also enhances a test that should have caught this type
of error.