### PR TITLE
Fix issue introduced by interaction between two recent PRs

### DIFF
--- a/operator/parser/regex/regex_test.go
+++ b/operator/parser/regex/regex_test.go
@@ -112,6 +112,7 @@ func TestParserRegex(t *testing.T) {
 				Body: "a=b",
 			},
 			&entry.Entry{
+				Body: "a=b",
 				Attributes: map[string]interface{}{
 					"a": "b",
 				},
@@ -127,6 +128,7 @@ func TestParserRegex(t *testing.T) {
 				Body: "coredns-5644d7b6d9-mzngq_kube-system_coredns-901f7510281180a402936c92f5bc0f3557f5a21ccb5a4591c5bf98f3ddbffdd6.log",
 			},
 			&entry.Entry{
+				Body: "coredns-5644d7b6d9-mzngq_kube-system_coredns-901f7510281180a402936c92f5bc0f3557f5a21ccb5a4591c5bf98f3ddbffdd6.log",
 				Attributes: map[string]interface{}{
 					"container_id":   "901f7510281180a402936c92f5bc0f3557f5a21ccb5a4591c5bf98f3ddbffdd6",
 					"container_name": "coredns",


### PR DESCRIPTION
The default value of parse_to was changed at the same time that
some new tests were added to the regex parser. The new tests did
not account for this, but no merge conflict existed.