### PR TITLE
Windows input fix

### DIFF
--- a/operator/input/windows/operator.go
+++ b/operator/input/windows/operator.go
@@ -230,7 +230,7 @@ func (e *EventLogInput) sendEvent(ctx context.Context, eventXML EventXML) {
 	}
 
 	entry.Timestamp = eventXML.parseTimestamp()
-	entry.Severity = eventXML.parseSeverity()
+	entry.Severity = eventXML.parseRenderedSeverity()
 	e.Write(ctx, entry)
 }
 

--- a/operator/input/windows/testdata/xmlSample.xml
+++ b/operator/input/windows/testdata/xmlSample.xml
@@ -1,0 +1,22 @@
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"> 
+    <System> 
+        <Provider Name="Microsoft-Windows-Security-SPP" Guid="{E23B33B0-C8C9-472C-A5F9-F2BDFEA0F156}" EventSourceName="Software Protection Platform Service" /> 
+        <EventID Qualifiers="16384">16384</EventID> 
+        <Version>0</Version> 
+        <Level>4</Level> 
+        <Task>0</Task> 
+        <Opcode>0</Opcode> 
+        <Keywords>0x80000000000000</Keywords> 
+        <TimeCreated SystemTime="2022-04-22T10:20:52.3778625Z" /> 
+        <EventRecordID>23401</EventRecordID> 
+        <Correlation /> 
+        <Execution ProcessID="0" ThreadID="0" /> 
+        <Channel>Application</Channel> 
+        <Computer>computer</Computer> 
+        <Security /> 
+    </System> 
+    <EventData> 
+        <Data>2022-04-28T19:48:52Z</Data> 
+        <Data>RulesEngine</Data> 
+    </EventData> 
+</Event>

--- a/operator/input/windows/xml.go
+++ b/operator/input/windows/xml.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package windows
@@ -32,11 +33,11 @@ type EventXML struct {
 	Channel     string      `xml:"System>Channel"`
 	RecordID    uint64      `xml:"System>EventRecordID"`
 	TimeCreated TimeCreated `xml:"System>TimeCreated"`
-	Message     string      `xml:"RenderingInfo>Message"`
-	Level       string      `xml:"RenderingInfo>Level"`
-	Task        string      `xml:"RenderingInfo>Task"`
-	Opcode      string      `xml:"RenderingInfo>Opcode"`
-	Keywords    []string    `xml:"RenderingInfo>Keywords>Keyword"`
+	Message     string      `xml:"EventData>Data"`
+	Level       string      `xml:"System>Level"`
+	Task        string      `xml:"System>Task"`
+	Opcode      string      `xml:"System>Opcode"`
+	Keywords    []string    `xml:"System>Keywords>Keyword"`
 }
 
 // parseTimestamp will parse the timestamp of the event.

--- a/operator/input/windows/xml.go
+++ b/operator/input/windows/xml.go
@@ -27,17 +27,22 @@ import (
 
 // EventXML is the rendered xml of an event.
 type EventXML struct {
-	EventID     EventID     `xml:"System>EventID"`
-	Provider    Provider    `xml:"System>Provider"`
-	Computer    string      `xml:"System>Computer"`
-	Channel     string      `xml:"System>Channel"`
-	RecordID    uint64      `xml:"System>EventRecordID"`
-	TimeCreated TimeCreated `xml:"System>TimeCreated"`
-	Message     string      `xml:"EventData>Data"`
-	Level       string      `xml:"System>Level"`
-	Task        string      `xml:"System>Task"`
-	Opcode      string      `xml:"System>Opcode"`
-	Keywords    []string    `xml:"System>Keywords>Keyword"`
+	EventID          EventID     `xml:"System>EventID"`
+	Provider         Provider    `xml:"System>Provider"`
+	Computer         string      `xml:"System>Computer"`
+	Channel          string      `xml:"System>Channel"`
+	RecordID         uint64      `xml:"System>EventRecordID"`
+	TimeCreated      TimeCreated `xml:"System>TimeCreated"`
+	Message          string      `xml:"RenderingInfo>Message"`
+	RenderedLevel    string      `xml:"RenderingInfo>Level"`
+	Level            string      `xml:"System>Level"`
+	RenderedTask     string      `xml:"RenderingInfo>Task"`
+	Task             string      `xml:"System>Task"`
+	RenderedOpcode   string      `xml:"RenderingInfo>Opcode"`
+	Opcode           string      `xml:"System>Opcode"`
+	RenderedKeywords []string    `xml:"RenderingInfo>Keywords>Keyword"`
+	Keywords         []string    `xml:"System>Keywords"`
+	EventData        []string    `xml:"EventData>Data"`
 }
 
 // parseTimestamp will parse the timestamp of the event.
@@ -77,15 +82,20 @@ func (e *EventXML) parseBody() map[string]interface{} {
 			"guid":         e.Provider.GUID,
 			"event_source": e.Provider.EventSourceName,
 		},
-		"system_time": e.TimeCreated.SystemTime,
-		"computer":    e.Computer,
-		"channel":     e.Channel,
-		"record_id":   e.RecordID,
-		"level":       e.Level,
-		"message":     message,
-		"task":        e.Task,
-		"opcode":      e.Opcode,
-		"keywords":    e.Keywords,
+		"system_time":       e.TimeCreated.SystemTime,
+		"computer":          e.Computer,
+		"channel":           e.Channel,
+		"record_id":         e.RecordID,
+		"level":             e.Level,
+		"rendered_level":    e.RenderedLevel,
+		"message":           message,
+		"task":              e.Task,
+		"rendered_task":     e.RenderedTask,
+		"opcode":            e.Opcode,
+		"rendered_opcode":   e.RenderedOpcode,
+		"keywords":          e.Keywords,
+		"rendered_keywords": e.RenderedKeywords,
+		"event_data":        e.EventData,
 	}
 	if len(details) > 0 {
 		body["details"] = details

--- a/operator/input/windows/xml_test.go
+++ b/operator/input/windows/xml_test.go
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package windows
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -75,14 +78,19 @@ func TestParseBody(t *testing.T) {
 		TimeCreated: TimeCreated{
 			SystemTime: "2020-07-30T01:01:01.123456789Z",
 		},
-		Computer: "computer",
-		Channel:  "application",
-		RecordID: 1,
-		Level:    "Information",
-		Message:  "message",
-		Task:     "task",
-		Opcode:   "opcode",
-		Keywords: []string{"keyword"},
+		Computer:         "computer",
+		Channel:          "application",
+		RecordID:         1,
+		Level:            "Information",
+		Message:          "message",
+		Task:             "task",
+		Opcode:           "opcode",
+		Keywords:         []string{"keyword"},
+		EventData:        []string{"this", "is", "some", "sample", "data"},
+		RenderedLevel:    "rendered_level",
+		RenderedTask:     "rendered_task",
+		RenderedOpcode:   "rendered_opcode",
+		RenderedKeywords: []string{"RenderedKeywords"},
 	}
 
 	expected := map[string]interface{}{
@@ -95,16 +103,118 @@ func TestParseBody(t *testing.T) {
 			"guid":         "guid",
 			"event_source": "event source",
 		},
-		"system_time": "2020-07-30T01:01:01.123456789Z",
-		"computer":    "computer",
-		"channel":     "application",
-		"record_id":   uint64(1),
-		"level":       "Information",
-		"message":     "message",
-		"task":        "task",
-		"opcode":      "opcode",
-		"keywords":    []string{"keyword"},
+		"system_time":       "2020-07-30T01:01:01.123456789Z",
+		"computer":          "computer",
+		"channel":           "application",
+		"record_id":         uint64(1),
+		"level":             "Information",
+		"message":           "message",
+		"task":              "task",
+		"opcode":            "opcode",
+		"keywords":          []string{"keyword"},
+		"rendered_level":    "rendered_level",
+		"rendered_task":     "rendered_task",
+		"rendered_opcode":   "rendered_opcode",
+		"rendered_keywords": []string{"RenderedKeywords"},
+		"event_data":        []string{"this", "is", "some", "sample", "data"},
 	}
 
 	require.Equal(t, expected, xml.parseBody())
+}
+
+func TestParseBody2(t *testing.T) {
+	xml := EventXML{
+		EventID: EventID{
+			ID:         1,
+			Qualifiers: 2,
+		},
+		Provider: Provider{
+			Name:            "provider",
+			GUID:            "guid",
+			EventSourceName: "event source",
+		},
+		TimeCreated: TimeCreated{
+			SystemTime: "2020-07-30T01:01:01.123456789Z",
+		},
+		Computer:         "computer",
+		Channel:          "Security",
+		RecordID:         1,
+		Level:            "Information",
+		Message:          "message",
+		Task:             "task",
+		Opcode:           "opcode",
+		Keywords:         []string{"keyword"},
+		EventData:        []string{"this", "is", "some", "sample", "data"},
+		RenderedLevel:    "rendered_level",
+		RenderedTask:     "rendered_task",
+		RenderedOpcode:   "rendered_opcode",
+		RenderedKeywords: []string{"RenderedKeywords"},
+	}
+
+	expected := map[string]interface{}{
+		"event_id": map[string]interface{}{
+			"id":         uint32(1),
+			"qualifiers": uint16(2),
+		},
+		"provider": map[string]interface{}{
+			"name":         "provider",
+			"guid":         "guid",
+			"event_source": "event source",
+		},
+		"system_time":       "2020-07-30T01:01:01.123456789Z",
+		"computer":          "computer",
+		"channel":           "Security",
+		"record_id":         uint64(1),
+		"level":             "Information",
+		"message":           "message",
+		"task":              "task",
+		"opcode":            "opcode",
+		"keywords":          []string{"keyword"},
+		"rendered_level":    "rendered_level",
+		"rendered_task":     "rendered_task",
+		"rendered_opcode":   "rendered_opcode",
+		"rendered_keywords": []string{"RenderedKeywords"},
+		"event_data":        []string{"this", "is", "some", "sample", "data"},
+	}
+
+	require.Equal(t, expected, xml.parseBody())
+}
+
+func TestInvalidUnmarshal(t *testing.T) {
+	_, err := unmarshalEventXML([]byte("Test \n Invalid \t Unmarshal"))
+	require.Error(t, err)
+
+}
+func TestUnmarshal(t *testing.T) {
+	data, err := ioutil.ReadFile(filepath.Join("testdata", "xmlSample.xml"))
+	require.NoError(t, err)
+
+	event, err := unmarshalEventXML(data)
+	require.NoError(t, err)
+
+	xml := EventXML{
+		EventID: EventID{
+			ID:         16384,
+			Qualifiers: 16384,
+		},
+		Provider: Provider{
+			Name:            "Microsoft-Windows-Security-SPP",
+			GUID:            "{E23B33B0-C8C9-472C-A5F9-F2BDFEA0F156}",
+			EventSourceName: "Software Protection Platform Service",
+		},
+		TimeCreated: TimeCreated{
+			SystemTime: "2022-04-22T10:20:52.3778625Z",
+		},
+		Computer:  "computer",
+		Channel:   "Application",
+		RecordID:  23401,
+		Level:     "4",
+		Message:   "",
+		Task:      "0",
+		Opcode:    "0",
+		EventData: []string{"2022-04-28T19:48:52Z", "RulesEngine"},
+		Keywords:  []string{"0x80000000000000"},
+	}
+
+	require.Equal(t, xml, event)
 }


### PR DESCRIPTION
**Changes**
- Implemented fix for the Windows Event Log Input Operator. 
- Main fix was to the `xml.go` file.
- Added tests in `xml_test.go` and a sample WEL xml file
 
**Link to Tracking Issue**
#476 

