### PR TITLE
Bug Fix - Windows Buffer 

### DIFF
--- a/operator/input/windows/buffer.go
+++ b/operator/input/windows/buffer.go
@@ -91,7 +91,7 @@ func NewBuffer() Buffer {
 	}
 }
 
-this function reallocates the memory used for the buffer, effectively resetting the contents
+// Reset reallocates the memory used for the buffer, effectively resetting the contents
 func (b *Buffer) Reset() {
 	b.buffer = make([]byte, defaultBufferSize)
 }

--- a/operator/input/windows/buffer.go
+++ b/operator/input/windows/buffer.go
@@ -90,3 +90,8 @@ func NewBuffer() Buffer {
 		buffer: make([]byte, defaultBufferSize),
 	}
 }
+
+this function reallocates the memory used for the buffer, effectively resetting the contents
+func (b *Buffer) Reset() {
+	b.buffer = make([]byte, defaultBufferSize)
+}

--- a/operator/input/windows/operator.go
+++ b/operator/input/windows/operator.go
@@ -196,7 +196,7 @@ func (e *EventLogInput) read(ctx context.Context) int {
 
 // processEvent will process and send an event retrieved from windows event log.
 func (e *EventLogInput) processEvent(ctx context.Context, event Event) {
-	simpleEvent, err := event.RenderSimple(e.buffer)
+	simpleEvent, err := event.RenderSimple(e.buffer, e.Logger())
 	if err != nil {
 		e.Errorf("Failed to render simple event: %s", err)
 		return


### PR DESCRIPTION
**Description**
Windows has been responding back with incorrect value for the amount of buffer used when writing event logs. 

**Fix**
Reset the buffer, after running `evtRender()` check to see amount of buffer used to write event, if bufferUsed == 0, use the entire length of the buffer to read in the event.